### PR TITLE
fix: (#206) attempt to prevent ability crash

### DIFF
--- a/src/main/java/com/wanderersoftherift/wotr/abilities/AbilityContext.java
+++ b/src/main/java/com/wanderersoftherift/wotr/abilities/AbilityContext.java
@@ -12,6 +12,7 @@ import net.minecraft.world.entity.ai.attributes.AttributeInstance;
 import net.minecraft.world.entity.ai.attributes.AttributeModifier;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * The context for processing an ability.
@@ -19,7 +20,7 @@ import net.minecraft.world.level.Level;
  * @param caster      The caster of the ability
  * @param abilityItem The item holding the ability (and any upgrades)
  */
-public record AbilityContext(LivingEntity caster, ItemStack abilityItem) {
+public record AbilityContext(@NotNull LivingEntity caster, ItemStack abilityItem) {
 
     /**
      * @return The level the ability was used within

--- a/src/main/java/com/wanderersoftherift/wotr/entity/projectile/SimpleEffectProjectile.java
+++ b/src/main/java/com/wanderersoftherift/wotr/entity/projectile/SimpleEffectProjectile.java
@@ -416,13 +416,12 @@ public class SimpleEffectProjectile extends Projectile implements GeoEntity {
         }
 
         if (this.level() instanceof ServerLevel serverLevel && effect != null) {
-            LivingEntity caster = null;
-            if (owner instanceof LivingEntity livingOwner) {
-                caster = livingOwner;
+            if (!(owner instanceof LivingEntity livingOwner)) {
+                return;
             }
             // TODO: capture and carry across ability item
             effect.applyDelayed(serverLevel, entity, List.of(entity.blockPosition()),
-                    new AbilityContext(caster, ItemStack.EMPTY));
+                    new AbilityContext(livingOwner, ItemStack.EMPTY));
         }
 
         if (this.getPierceLevel() <= 0) {
@@ -459,12 +458,11 @@ public class SimpleEffectProjectile extends Projectile implements GeoEntity {
         this.lastState = this.level().getBlockState(result.getBlockPos());
         super.onHitBlock(result);
         ItemStack itemstack = this.getWeaponItem();
-        if (this.level() instanceof ServerLevel serverLevel) {
-            if (effect != null) {
-                // TODO: capture and carry across ability item
-                effect.applyDelayed(serverLevel, null, List.of(result.getBlockPos()),
-                        new AbilityContext((LivingEntity) this.getOwner(), ItemStack.EMPTY));
-            }
+        if (effect != null && this.level() instanceof ServerLevel serverLevel
+                && this.getOwner() instanceof LivingEntity caster) {
+            // TODO: capture and carry across ability item
+            effect.applyDelayed(serverLevel, null, List.of(result.getBlockPos()),
+                    new AbilityContext(caster, ItemStack.EMPTY));
         }
 
         Vec3 vec31 = this.getDeltaMovement();


### PR DESCRIPTION
Adds extra checks and handling of null caster situations relating to projectile effects.

Closes #206 