### PR TITLE
Fix: Fixed tooltip crash for implicit modifiers

### DIFF
--- a/src/main/java/com/wanderersoftherift/wotr/modifier/Modifier.java
+++ b/src/main/java/com/wanderersoftherift/wotr/modifier/Modifier.java
@@ -17,16 +17,15 @@ import net.minecraft.world.item.ItemStack;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 public class Modifier {
     public static final Codec<Modifier> DIRECT_CODEC = RecordCodecBuilder.create(inst -> inst.group(
             ModifierTier.CODEC.listOf().fieldOf("tiers").forGetter(Modifier::getModifierTierList),
-            Style.Serializer.CODEC.optionalFieldOf("style").forGetter(mod -> Optional.of(mod.getStyle()))
-    )
-            .apply(inst, (tiers, styleOpt) -> new Modifier(tiers,
-                    styleOpt.orElse(Style.EMPTY.withColor(ChatFormatting.GRAY)))));
+            Style.Serializer.CODEC.optionalFieldOf("style", Style.EMPTY.withColor(ChatFormatting.GRAY))
+                    .forGetter(Modifier::getStyle))
+            .apply(inst, Modifier::new)
+    );
     public static final Codec<Holder<Modifier>> CODEC = RegistryFixedCodec.create(WotrRegistries.Keys.MODIFIERS);
     public static final StreamCodec<RegistryFriendlyByteBuf, Holder<Modifier>> STREAM_CODEC = ByteBufCodecs
             .holderRegistry(WotrRegistries.Keys.MODIFIERS);

--- a/src/main/java/com/wanderersoftherift/wotr/modifier/Modifier.java
+++ b/src/main/java/com/wanderersoftherift/wotr/modifier/Modifier.java
@@ -42,7 +42,7 @@ public class Modifier {
     }
 
     public Style getStyle() {
-        if(style == null) {
+        if (style == null) {
             return Style.EMPTY.withColor(ChatFormatting.GRAY);
         }
 

--- a/src/main/java/com/wanderersoftherift/wotr/modifier/Modifier.java
+++ b/src/main/java/com/wanderersoftherift/wotr/modifier/Modifier.java
@@ -23,8 +23,10 @@ import java.util.stream.Collectors;
 public class Modifier {
     public static final Codec<Modifier> DIRECT_CODEC = RecordCodecBuilder.create(inst -> inst.group(
             ModifierTier.CODEC.listOf().fieldOf("tiers").forGetter(Modifier::getModifierTierList),
-            Style.Serializer.CODEC.optionalFieldOf("style").forGetter(mod -> Optional.ofNullable(mod.getStyle()))
-    ).apply(inst, (tiers, styleOpt) -> new Modifier(tiers, styleOpt.orElse(null))));
+            Style.Serializer.CODEC.optionalFieldOf("style").forGetter(mod -> Optional.of(mod.getStyle()))
+    )
+            .apply(inst, (tiers, styleOpt) -> new Modifier(tiers,
+                    styleOpt.orElse(Style.EMPTY.withColor(ChatFormatting.GRAY)))));
     public static final Codec<Holder<Modifier>> CODEC = RegistryFixedCodec.create(WotrRegistries.Keys.MODIFIERS);
     public static final StreamCodec<RegistryFriendlyByteBuf, Holder<Modifier>> STREAM_CODEC = ByteBufCodecs
             .holderRegistry(WotrRegistries.Keys.MODIFIERS);
@@ -42,10 +44,6 @@ public class Modifier {
     }
 
     public Style getStyle() {
-        if (style == null) {
-            return Style.EMPTY.withColor(ChatFormatting.GRAY);
-        }
-
         return style;
     }
 

--- a/src/main/java/com/wanderersoftherift/wotr/modifier/Modifier.java
+++ b/src/main/java/com/wanderersoftherift/wotr/modifier/Modifier.java
@@ -4,6 +4,7 @@ import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import com.wanderersoftherift.wotr.init.WotrRegistries;
 import com.wanderersoftherift.wotr.modifier.source.ModifierSource;
+import net.minecraft.ChatFormatting;
 import net.minecraft.core.Holder;
 import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.chat.Style;
@@ -41,6 +42,10 @@ public class Modifier {
     }
 
     public Style getStyle() {
+        if(style == null) {
+            return Style.EMPTY.withColor(ChatFormatting.GRAY);
+        }
+
         return style;
     }
 

--- a/src/main/resources/data/wotr/wotr/modifier/implicit/chainmail_boots.json
+++ b/src/main/resources/data/wotr/wotr/modifier/implicit/chainmail_boots.json
@@ -1,4 +1,7 @@
 {
+  "style": {
+    "color": "#7f8c8b"
+  },
   "tiers": [
     {
       "tier": 1,

--- a/src/main/resources/data/wotr/wotr/modifier/implicit/chainmail_chestplate.json
+++ b/src/main/resources/data/wotr/wotr/modifier/implicit/chainmail_chestplate.json
@@ -1,4 +1,7 @@
 {
+  "style": {
+    "color": "#7f8c8b"
+  },
   "tiers": [
     {
       "tier": 1,

--- a/src/main/resources/data/wotr/wotr/modifier/implicit/chainmail_helmet.json
+++ b/src/main/resources/data/wotr/wotr/modifier/implicit/chainmail_helmet.json
@@ -1,4 +1,7 @@
 {
+  "style": {
+    "color": "#7f8c8b"
+  },
   "tiers": [
     {
       "tier": 1,

--- a/src/main/resources/data/wotr/wotr/modifier/implicit/chainmail_leggings.json
+++ b/src/main/resources/data/wotr/wotr/modifier/implicit/chainmail_leggings.json
@@ -1,4 +1,7 @@
 {
+  "style": {
+    "color": "#7f8c8b"
+  },
   "tiers": [
     {
       "tier": 1,

--- a/src/main/resources/data/wotr/wotr/modifier/implicit/diamond_boots.json
+++ b/src/main/resources/data/wotr/wotr/modifier/implicit/diamond_boots.json
@@ -1,4 +1,7 @@
 {
+  "style": {
+    "color": "#4169E1"
+  },
   "tiers": [
     {
       "tier": 1,

--- a/src/main/resources/data/wotr/wotr/modifier/implicit/diamond_chestplate.json
+++ b/src/main/resources/data/wotr/wotr/modifier/implicit/diamond_chestplate.json
@@ -1,4 +1,7 @@
 {
+  "style": {
+    "color": "#4169E1"
+  },
   "tiers": [
     {
       "tier": 1,

--- a/src/main/resources/data/wotr/wotr/modifier/implicit/diamond_helmet.json
+++ b/src/main/resources/data/wotr/wotr/modifier/implicit/diamond_helmet.json
@@ -1,4 +1,7 @@
 {
+  "style": {
+    "color": "#4169E1"
+  },
   "tiers": [
     {
       "tier": 1,

--- a/src/main/resources/data/wotr/wotr/modifier/implicit/diamond_leggings.json
+++ b/src/main/resources/data/wotr/wotr/modifier/implicit/diamond_leggings.json
@@ -1,4 +1,7 @@
 {
+  "style": {
+    "color": "#4169E1"
+  },
   "tiers": [
     {
       "tier": 1,

--- a/src/main/resources/data/wotr/wotr/modifier/implicit/golden_boots.json
+++ b/src/main/resources/data/wotr/wotr/modifier/implicit/golden_boots.json
@@ -1,4 +1,7 @@
 {
+  "style": {
+    "color": "#00FA9A"
+  },
   "tiers": [
     {
       "tier": 1,

--- a/src/main/resources/data/wotr/wotr/modifier/implicit/golden_chestplate.json
+++ b/src/main/resources/data/wotr/wotr/modifier/implicit/golden_chestplate.json
@@ -1,4 +1,7 @@
 {
+  "style": {
+    "color": "#00FA9A"
+  },
   "tiers": [
     {
       "tier": 1,

--- a/src/main/resources/data/wotr/wotr/modifier/implicit/golden_helmet.json
+++ b/src/main/resources/data/wotr/wotr/modifier/implicit/golden_helmet.json
@@ -1,4 +1,7 @@
 {
+  "style": {
+    "color": "#00FA9A"
+  },
   "tiers": [
     {
       "tier": 1,

--- a/src/main/resources/data/wotr/wotr/modifier/implicit/golden_leggings.json
+++ b/src/main/resources/data/wotr/wotr/modifier/implicit/golden_leggings.json
@@ -1,4 +1,7 @@
 {
+  "style": {
+    "color": "#00FA9A"
+  },
   "tiers": [
     {
       "tier": 1,

--- a/src/main/resources/data/wotr/wotr/modifier/implicit/iron_boots.json
+++ b/src/main/resources/data/wotr/wotr/modifier/implicit/iron_boots.json
@@ -1,4 +1,7 @@
 {
+  "style": {
+    "color": "#7f8c8b"
+  },
   "tiers": [
     {
       "tier": 1,

--- a/src/main/resources/data/wotr/wotr/modifier/implicit/iron_chestplate.json
+++ b/src/main/resources/data/wotr/wotr/modifier/implicit/iron_chestplate.json
@@ -1,4 +1,7 @@
 {
+  "style": {
+    "color": "#7f8c8b"
+  },
   "tiers": [
     {
       "tier": 1,

--- a/src/main/resources/data/wotr/wotr/modifier/implicit/iron_helmet.json
+++ b/src/main/resources/data/wotr/wotr/modifier/implicit/iron_helmet.json
@@ -1,4 +1,7 @@
 {
+  "style": {
+    "color": "#7f8c8b"
+  },
   "tiers": [
     {
       "tier": 1,

--- a/src/main/resources/data/wotr/wotr/modifier/implicit/iron_leggings.json
+++ b/src/main/resources/data/wotr/wotr/modifier/implicit/iron_leggings.json
@@ -1,4 +1,7 @@
 {
+  "style": {
+    "color": "#7f8c8b"
+  },
   "tiers": [
     {
       "tier": 1,

--- a/src/main/resources/data/wotr/wotr/modifier/implicit/leather_boots.json
+++ b/src/main/resources/data/wotr/wotr/modifier/implicit/leather_boots.json
@@ -1,4 +1,7 @@
 {
+  "style": {
+    "color": "#00BFFF"
+  },
   "tiers": [
     {
       "tier": 1,

--- a/src/main/resources/data/wotr/wotr/modifier/implicit/leather_chestplate.json
+++ b/src/main/resources/data/wotr/wotr/modifier/implicit/leather_chestplate.json
@@ -1,4 +1,7 @@
 {
+  "style": {
+    "color": "#00BFFF"
+  },
   "tiers": [
     {
       "tier": 1,

--- a/src/main/resources/data/wotr/wotr/modifier/implicit/leather_helmet.json
+++ b/src/main/resources/data/wotr/wotr/modifier/implicit/leather_helmet.json
@@ -1,4 +1,7 @@
 {
+  "style": {
+    "color": "#00BFFF"
+  },
   "tiers": [
     {
       "tier": 1,

--- a/src/main/resources/data/wotr/wotr/modifier/implicit/leather_leggings.json
+++ b/src/main/resources/data/wotr/wotr/modifier/implicit/leather_leggings.json
@@ -1,4 +1,7 @@
 {
+  "style": {
+    "color": "#00BFFF"
+  },
   "tiers": [
     {
       "tier": 1,


### PR DESCRIPTION
When a null Style is passed in for the tooltip, defaults to gray instead of crashing.