### PR TITLE
Fix: Removed command 'riftkey tier' limit

### DIFF
--- a/src/main/java/com/wanderersoftherift/wotr/commands/RiftKeyCommands.java
+++ b/src/main/java/com/wanderersoftherift/wotr/commands/RiftKeyCommands.java
@@ -41,7 +41,7 @@ public class RiftKeyCommands extends BaseCommand {
         String objectiveArg = "objective";
         String seedArg = "seed";
         builder.then(Commands.literal("tier")
-                .then(Commands.argument(tierArg, IntegerArgumentType.integer(0, 7))
+                .then(Commands.argument(tierArg, IntegerArgumentType.integer())
                         .executes(ctx -> configTier(ctx, IntegerArgumentType.getInteger(ctx, tierArg)))))
                 .then(Commands.literal("theme")
                         .then(Commands.argument(themeArg, ResourceKeyArgument.key(WotrRegistries.Keys.RIFT_THEMES))

--- a/src/main/java/com/wanderersoftherift/wotr/commands/RiftKeyCommands.java
+++ b/src/main/java/com/wanderersoftherift/wotr/commands/RiftKeyCommands.java
@@ -41,7 +41,7 @@ public class RiftKeyCommands extends BaseCommand {
         String objectiveArg = "objective";
         String seedArg = "seed";
         builder.then(Commands.literal("tier")
-                .then(Commands.argument(tierArg, IntegerArgumentType.integer())
+                .then(Commands.argument(tierArg, IntegerArgumentType.integer(0))
                         .executes(ctx -> configTier(ctx, IntegerArgumentType.getInteger(ctx, tierArg)))))
                 .then(Commands.literal("theme")
                         .then(Commands.argument(themeArg, ResourceKeyArgument.key(WotrRegistries.Keys.RIFT_THEMES))


### PR DESCRIPTION
Removes the limit (7) from the riftkey tier command. Issue #293