### PR TITLE
fix: #327 isEmpty() method for RiftEntryState to correct bad ==s.

### DIFF
--- a/src/main/java/com/wanderersoftherift/wotr/core/inventory/snapshot/InventorySnapshotEvents.java
+++ b/src/main/java/com/wanderersoftherift/wotr/core/inventory/snapshot/InventorySnapshotEvents.java
@@ -17,7 +17,7 @@ public class InventorySnapshotEvents {
             return;
         }
         var deathRiftEntryState = player.getData(WotrAttachments.DEATH_RIFT_ENTRY_STATE);
-        if (deathRiftEntryState == RiftEntryState.EMPTY) {
+        if (deathRiftEntryState.isEmpty()) {
             return;
         }
         var remainingRiftEntryStates = player.getData(WotrAttachments.RIFT_ENTRY_STATES);

--- a/src/main/java/com/wanderersoftherift/wotr/core/rift/RiftEntryState.java
+++ b/src/main/java/com/wanderersoftherift/wotr/core/rift/RiftEntryState.java
@@ -16,10 +16,11 @@ import net.minecraft.world.phys.Vec3;
 public record RiftEntryState(InventorySnapshot entranceInventory, ResourceKey<Level> previousDimension,
         ResourceKey<Level> riftDimension, Vec3 previousPosition, StatSnapshot statSnapshot) {
 
-    public static final RiftEntryState EMPTY = new RiftEntryState(new InventorySnapshot(),
-            ResourceKey.create(Registries.DIMENSION, WanderersOfTheRift.id("empty")),
-            ResourceKey.create(Registries.DIMENSION, WanderersOfTheRift.id("empty")), new Vec3(0, 0, 0),
-            new StatSnapshot());
+    public static final ResourceKey<Level> EMPTY_DIMENSION = ResourceKey.create(Registries.DIMENSION,
+            WanderersOfTheRift.id("empty"));
+
+    public static final RiftEntryState EMPTY = new RiftEntryState(new InventorySnapshot(), EMPTY_DIMENSION,
+            EMPTY_DIMENSION, new Vec3(0, 0, 0), new StatSnapshot());
 
     public static final Codec<RiftEntryState> CODEC = RecordCodecBuilder.create(ins -> ins.group(
             InventorySnapshot.CODEC.fieldOf("entrance_inventory").forGetter(RiftEntryState::entranceInventory),
@@ -38,5 +39,9 @@ public record RiftEntryState(InventorySnapshot entranceInventory, ResourceKey<Le
                         currentEntryStates.stream().map(it -> it.entranceInventory).toList()),
                 player.level().dimension(), riftDimension, player.position(), new StatSnapshot(player));
         currentEntryStates.add(newEntryState);
+    }
+
+    public boolean isEmpty() {
+        return EMPTY_DIMENSION.equals(previousDimension) && EMPTY_DIMENSION.equals(riftDimension);
     }
 }

--- a/src/main/java/com/wanderersoftherift/wotr/core/rift/RiftEvents.java
+++ b/src/main/java/com/wanderersoftherift/wotr/core/rift/RiftEvents.java
@@ -73,7 +73,7 @@ public class RiftEvents {
             return;
         }
         var deathRiftEntryState = player.getData(WotrAttachments.DEATH_RIFT_ENTRY_STATE);
-        if (deathRiftEntryState == RiftEntryState.EMPTY) {
+        if (deathRiftEntryState.isEmpty()) {
             return;
         }
         var newRift = RiftLevelManager.getRiftLevel(deathRiftEntryState.previousDimension());

--- a/src/main/java/com/wanderersoftherift/wotr/rift/objective/RiftObjectiveEvents.java
+++ b/src/main/java/com/wanderersoftherift/wotr/rift/objective/RiftObjectiveEvents.java
@@ -83,15 +83,15 @@ public class RiftObjectiveEvents {
         if (!(event.getEntity() instanceof ServerPlayer player)) {
             return;
         }
-        var deathRiftEntryState = player.getData(WotrAttachments.DEATH_RIFT_ENTRY_STATE);
-        if (deathRiftEntryState == RiftEntryState.EMPTY) {
+        RiftEntryState entryState = player.getData(WotrAttachments.DEATH_RIFT_ENTRY_STATE);
+        if (entryState.isEmpty()) {
             return;
         }
         // TODO: what if player dies in multiple rifts simultaneously?
         player.openMenu(new SimpleMenuProvider(
                 (containerId, playerInventory, p) -> new RiftCompleteMenu(containerId, playerInventory,
                         ContainerLevelAccess.create(player.level(), p.getOnPos()), RiftCompleteMenu.FLAG_FAILED,
-                        deathRiftEntryState.statSnapshot().getCustomStatDelta(player)),
+                        entryState.statSnapshot().getCustomStatDelta(player)),
                 Component.translatable(WanderersOfTheRift.translationId("container", "rift_complete"))));
         if (player.containerMenu instanceof RiftCompleteMenu menu) {
             // TODO: Do we need rift config for losing a rift?
@@ -108,7 +108,7 @@ public class RiftObjectiveEvents {
         var exitedRiftEntryState = player.getData(WotrAttachments.EXITED_RIFT_ENTRY_STATE);
         ServerLevel riftLevel = RiftLevelManager.getRiftLevel(exitedRiftEntryState.riftDimension());
 
-        if (riftLevel == null || exitedRiftEntryState == RiftEntryState.EMPTY) {
+        if (riftLevel == null || exitedRiftEntryState.isEmpty()) {
             return;
         }
         RiftData riftData = RiftData.get(riftLevel);


### PR DESCRIPTION
Assumption that the singleton instance of RiftEntryState would be maintained seems to be bad, I assume the data attachment system serializes/deserializes them into new instances, probably across the new entity creation as a player respawns. Added an isEmpty() method to do the check instead.