### PR TITLE
(#298) Quest Giver support

### DIFF
--- a/src/generated/resources/assets/wotr/items/noir_helmet.json
+++ b/src/generated/resources/assets/wotr/items/noir_helmet.json
@@ -1,0 +1,6 @@
+{
+  "model": {
+    "type": "minecraft:model",
+    "model": "wotr:item/noir_helmet"
+  }
+}

--- a/src/generated/resources/assets/wotr/lang/en_us.json
+++ b/src/generated/resources/assets/wotr/lang/en_us.json
@@ -519,6 +519,8 @@
   "objective.wotr.nothing.name": "Nothing",
   "objective.wotr.stealth.description": "Defeat monsters stealthily",
   "objective.wotr.stealth.name": "Stealth",
+  "quest.wotr.bring_fish.description": "I'm starving. Could you purlease bring me a fish?",
+  "quest.wotr.bring_fish.title": "Fish of the day",
   "quest.wotr.complete_rift.description": "Prove your mettle.",
   "quest.wotr.complete_rift.title": "Complete Rifts",
   "quest.wotr.fetch_quest.description": "Bring me what I need and I'll make it worth your while.",

--- a/src/main/java/com/wanderersoftherift/wotr/WanderersOfTheRift.java
+++ b/src/main/java/com/wanderersoftherift/wotr/WanderersOfTheRift.java
@@ -20,6 +20,7 @@ import com.wanderersoftherift.wotr.init.WotrEquipmentSlotTypes;
 import com.wanderersoftherift.wotr.init.WotrItems;
 import com.wanderersoftherift.wotr.init.WotrMenuTypes;
 import com.wanderersoftherift.wotr.init.WotrMobEffects;
+import com.wanderersoftherift.wotr.init.WotrMobInteractions;
 import com.wanderersoftherift.wotr.init.WotrModifierEffectTypes;
 import com.wanderersoftherift.wotr.init.WotrModifierSourceTypes;
 import com.wanderersoftherift.wotr.init.WotrObjectiveTypes;
@@ -133,6 +134,8 @@ public class WanderersOfTheRift {
         WotrRewardTypes.REWARD_PROVIDER_TYPES.register(modEventBus);
         WotrRewardTypes.REWARD_TYPES.register(modEventBus);
         WotrTrackedAbilityTriggers.TRIGGERS.register(modEventBus);
+
+        WotrMobInteractions.MOB_INTERACTIONS.register(modEventBus);
 
         // Gear
         WotrModifierSourceTypes.MODIFIER_SOURCE.register(modEventBus);

--- a/src/main/java/com/wanderersoftherift/wotr/block/QuestHubBlock.java
+++ b/src/main/java/com/wanderersoftherift/wotr/block/QuestHubBlock.java
@@ -1,35 +1,18 @@
 package com.wanderersoftherift.wotr.block;
 
 import com.wanderersoftherift.wotr.WanderersOfTheRift;
-import com.wanderersoftherift.wotr.core.quest.ActiveQuests;
-import com.wanderersoftherift.wotr.core.quest.Quest;
-import com.wanderersoftherift.wotr.core.quest.QuestState;
-import com.wanderersoftherift.wotr.gui.menu.quest.QuestCompletionMenu;
-import com.wanderersoftherift.wotr.gui.menu.quest.QuestGiverMenu;
-import com.wanderersoftherift.wotr.init.WotrAttachments;
-import com.wanderersoftherift.wotr.init.WotrRegistries;
-import com.wanderersoftherift.wotr.network.quest.AvailableQuestsPayload;
+import com.wanderersoftherift.wotr.core.quest.QuestMenuHelper;
 import net.minecraft.core.BlockPos;
-import net.minecraft.core.Registry;
 import net.minecraft.network.chat.Component;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.InteractionResult;
-import net.minecraft.world.SimpleMenuProvider;
 import net.minecraft.world.entity.player.Player;
-import net.minecraft.world.inventory.ContainerLevelAccess;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockBehaviour;
 import net.minecraft.world.level.block.state.BlockState;
-import net.minecraft.world.level.storage.loot.LootParams;
-import net.minecraft.world.level.storage.loot.parameters.LootContextParamSets;
 import net.minecraft.world.phys.BlockHitResult;
-import net.neoforged.neoforge.network.PacketDistributor;
 import org.jetbrains.annotations.NotNull;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  * A block that provides access to selecting and completing quests
@@ -38,7 +21,6 @@ public class QuestHubBlock extends Block {
 
     public static final Component CONTAINER_TITLE = Component
             .translatable(WanderersOfTheRift.translationId("container", "quest.selection"));
-    private static final int QUEST_SELECTION_SIZE = 5;
 
     public QuestHubBlock(BlockBehaviour.Properties properties) {
         super(properties);
@@ -54,53 +36,8 @@ public class QuestHubBlock extends Block {
             return InteractionResult.SUCCESS;
         }
 
-        ActiveQuests activeQuests = player.getData(WotrAttachments.ACTIVE_QUESTS);
-        if (activeQuests.isEmpty()) {
-            List<QuestState> availableQuests = getAvailableQuests(level, serverPlayer);
-
-            player.openMenu(
-                    new SimpleMenuProvider(
-                            (containerId, playerInventory, p) -> new QuestGiverMenu(containerId, playerInventory,
-                                    ContainerLevelAccess.create(level, pos), new ArrayList<>(availableQuests)),
-                            CONTAINER_TITLE)
-            );
-            PacketDistributor.sendToPlayer(serverPlayer, new AvailableQuestsPayload(availableQuests));
-        } else {
-            player.openMenu(
-                    new SimpleMenuProvider(
-                            (containerId, playerInventory, p) -> new QuestCompletionMenu(containerId, playerInventory,
-                                    ContainerLevelAccess.create(level, pos), activeQuests,
-                                    activeQuests.getQuestList().getFirst().getId()),
-                            Component.empty())
-            );
-        }
+        QuestMenuHelper.openQuestMenu(serverPlayer, CONTAINER_TITLE, pos, this);
         return InteractionResult.CONSUME;
     }
 
-    private static @NotNull List<QuestState> getAvailableQuests(Level level, ServerPlayer serverPlayer) {
-        List<QuestState> availableQuests = serverPlayer.getData(WotrAttachments.AVAILABLE_QUESTS);
-        if (serverPlayer.getData(WotrAttachments.AVAILABLE_QUESTS).isEmpty()) {
-            availableQuests = generateNewQuestList(level, serverPlayer);
-            serverPlayer.setData(WotrAttachments.AVAILABLE_QUESTS, availableQuests);
-        }
-        return availableQuests;
-    }
-
-    private static @NotNull List<QuestState> generateNewQuestList(Level level, ServerPlayer serverPlayer) {
-        LootParams params = new LootParams.Builder(serverPlayer.serverLevel()).create(LootContextParamSets.EMPTY);
-        Registry<Quest> questRegistry = level.registryAccess().lookupOrThrow(WotrRegistries.Keys.QUESTS);
-        List<Quest> quests = questRegistry.stream().collect(Collectors.toList());
-        List<QuestState> generatedQuests = new ArrayList<>();
-        for (int i = 0; i < QUEST_SELECTION_SIZE && !quests.isEmpty(); i++) {
-            int index = level.random.nextInt(quests.size());
-            Quest quest = quests.get(index);
-            if (index < quests.size() - 1) {
-                quest = quests.set(index, quests.getLast());
-            }
-            quests.removeLast();
-            generatedQuests.add(new QuestState(questRegistry.wrapAsHolder(quest), quest.generateGoals(params),
-                    quest.generateRewards(params)));
-        }
-        return generatedQuests;
-    }
 }

--- a/src/main/java/com/wanderersoftherift/wotr/commands/DebugCommands.java
+++ b/src/main/java/com/wanderersoftherift/wotr/commands/DebugCommands.java
@@ -3,14 +3,18 @@ package com.wanderersoftherift.wotr.commands;
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import com.mojang.brigadier.context.CommandContext;
 import com.wanderersoftherift.wotr.WanderersOfTheRift;
+import com.wanderersoftherift.wotr.entity.npc.QuestGiverInteract;
+import com.wanderersoftherift.wotr.init.WotrAttachments;
 import net.minecraft.ChatFormatting;
 import net.minecraft.commands.CommandBuildContext;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.Commands;
+import net.minecraft.commands.arguments.EntityArgument;
 import net.minecraft.core.component.TypedDataComponent;
 import net.minecraft.network.chat.Component;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.entity.Entity;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.GameRules;
 import net.minecraft.world.level.Level;
@@ -27,6 +31,14 @@ public class DebugCommands extends BaseCommand {
     protected void buildCommand(LiteralArgumentBuilder<CommandSourceStack> builder, CommandBuildContext context) {
         builder.then(Commands.literal("devWorld").executes(this::devWorld));
         builder.then(Commands.literal("getItemStackComponents").executes(this::getItemStackComponents));
+        builder.then(Commands.literal("makeQuestGiver")
+                .then(Commands.argument("mob", EntityArgument.entity())
+                        .executes(ctx -> makeQuestGiver(ctx, EntityArgument.getEntity(ctx, "mob")))));
+    }
+
+    private int makeQuestGiver(CommandContext<CommandSourceStack> context, Entity mob) {
+        mob.setData(WotrAttachments.MOB_INTERACT, QuestGiverInteract.INSTANCE);
+        return 1;
     }
 
     private int devWorld(CommandContext<CommandSourceStack> stack) {

--- a/src/main/java/com/wanderersoftherift/wotr/core/quest/Quest.java
+++ b/src/main/java/com/wanderersoftherift/wotr/core/quest/Quest.java
@@ -4,7 +4,9 @@ import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import com.wanderersoftherift.wotr.init.WotrRegistries;
 import net.minecraft.core.Holder;
+import net.minecraft.core.HolderSet;
 import net.minecraft.network.chat.Component;
+import net.minecraft.resources.HolderSetCodec;
 import net.minecraft.resources.RegistryFixedCodec;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.level.storage.loot.LootParams;
@@ -28,6 +30,8 @@ public record Quest(Optional<ResourceLocation> icon, List<GoalProvider> goals, L
     ).apply(instance, Quest::new));
 
     public static final Codec<Holder<Quest>> CODEC = RegistryFixedCodec.create(WotrRegistries.Keys.QUESTS);
+    public static final Codec<HolderSet<Quest>> SET_CODEC = HolderSetCodec.create(WotrRegistries.Keys.QUESTS, CODEC,
+            false);
 
     public List<Goal> generateGoals(LootParams params) {
         return goals.stream().flatMap(x -> x.generateGoal(params).stream()).toList();

--- a/src/main/java/com/wanderersoftherift/wotr/core/quest/QuestMenuHelper.java
+++ b/src/main/java/com/wanderersoftherift/wotr/core/quest/QuestMenuHelper.java
@@ -1,0 +1,107 @@
+package com.wanderersoftherift.wotr.core.quest;
+
+import com.wanderersoftherift.wotr.gui.menu.ValidatingLevelAccess;
+import com.wanderersoftherift.wotr.gui.menu.quest.QuestCompletionMenu;
+import com.wanderersoftherift.wotr.gui.menu.quest.QuestGiverMenu;
+import com.wanderersoftherift.wotr.init.WotrAttachments;
+import com.wanderersoftherift.wotr.init.WotrRegistries;
+import com.wanderersoftherift.wotr.network.quest.AvailableQuestsPayload;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Registry;
+import net.minecraft.network.chat.Component;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.SimpleMenuProvider;
+import net.minecraft.world.entity.Mob;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.storage.loot.LootParams;
+import net.minecraft.world.level.storage.loot.parameters.LootContextParamSets;
+import net.neoforged.neoforge.network.PacketDistributor;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Common handling of opening quest related menus - at least while we have both the quest hub block and npc quest
+ * givers.
+ */
+public final class QuestMenuHelper {
+
+    private static final int QUEST_SELECTION_SIZE = 5;
+
+    private QuestMenuHelper() {
+    }
+
+    /**
+     * Opens the quest menu from a block
+     * 
+     * @param player
+     * @param title
+     * @param pos
+     * @param block
+     */
+    public static void openQuestMenu(ServerPlayer player, Component title, BlockPos pos, Block block) {
+        openQuestMenu(player, title, ValidatingLevelAccess.create(player.serverLevel(), pos, block));
+    }
+
+    /**
+     * Opens the quest menu from a given questGiver
+     * 
+     * @param player
+     * @param questGiver
+     */
+    public static void openQuestMenu(ServerPlayer player, Mob questGiver) {
+        openQuestMenu(player, questGiver.getDisplayName(), ValidatingLevelAccess.create(questGiver));
+    }
+
+    private static void openQuestMenu(ServerPlayer player, Component title, ValidatingLevelAccess access) {
+        ActiveQuests activeQuests = player.getData(WotrAttachments.ACTIVE_QUESTS);
+        if (activeQuests.isEmpty()) {
+            List<QuestState> availableQuests = getAvailableQuests(player.level(), player);
+
+            player.openMenu(
+                    new SimpleMenuProvider(
+                            (containerId, playerInventory, p) -> new QuestGiverMenu(containerId, playerInventory,
+                                    access, new ArrayList<>(availableQuests)),
+                            title)
+            );
+            PacketDistributor.sendToPlayer(player, new AvailableQuestsPayload(availableQuests));
+        } else {
+            player.openMenu(
+                    new SimpleMenuProvider(
+                            (containerId, playerInventory, p) -> new QuestCompletionMenu(containerId, playerInventory,
+                                    access, activeQuests, activeQuests.getQuestList().getFirst().getId()),
+                            Component.empty())
+            );
+        }
+    }
+
+    private static @NotNull List<QuestState> getAvailableQuests(Level level, ServerPlayer serverPlayer) {
+        List<QuestState> availableQuests = serverPlayer.getData(WotrAttachments.AVAILABLE_QUESTS);
+        if (serverPlayer.getData(WotrAttachments.AVAILABLE_QUESTS).isEmpty()) {
+            availableQuests = generateNewQuestList(level, serverPlayer);
+            serverPlayer.setData(WotrAttachments.AVAILABLE_QUESTS, availableQuests);
+        }
+        return availableQuests;
+    }
+
+    private static @NotNull List<QuestState> generateNewQuestList(Level level, ServerPlayer serverPlayer) {
+        LootParams params = new LootParams.Builder(serverPlayer.serverLevel()).create(LootContextParamSets.EMPTY);
+        Registry<Quest> questRegistry = level.registryAccess().lookupOrThrow(WotrRegistries.Keys.QUESTS);
+        List<Quest> quests = questRegistry.stream().collect(Collectors.toList());
+        List<QuestState> generatedQuests = new ArrayList<>();
+        for (int i = 0; i < QUEST_SELECTION_SIZE && !quests.isEmpty(); i++) {
+            int index = level.random.nextInt(quests.size());
+            Quest quest = quests.get(index);
+            if (index < quests.size() - 1) {
+                quest = quests.set(index, quests.getLast());
+            }
+            quests.removeLast();
+            generatedQuests.add(new QuestState(questRegistry.wrapAsHolder(quest), quest.generateGoals(params),
+                    quest.generateRewards(params)));
+        }
+        return generatedQuests;
+    }
+}

--- a/src/main/java/com/wanderersoftherift/wotr/datagen/WotrLanguageProvider.java
+++ b/src/main/java/com/wanderersoftherift/wotr/datagen/WotrLanguageProvider.java
@@ -469,6 +469,9 @@ public class WotrLanguageProvider extends LanguageProvider {
         add(WanderersOfTheRift.translationId("quest", "kill_skeletons.description"), "Bones scare me! Save me!");
         add(WanderersOfTheRift.translationId("quest", "complete_rift.title"), "Complete Rifts");
         add(WanderersOfTheRift.translationId("quest", "complete_rift.description"), "Prove your mettle.");
+        add(WanderersOfTheRift.translationId("quest", "bring_fish.title"), "Fish of the day");
+        add(WanderersOfTheRift.translationId("quest", "bring_fish.description"),
+                "I'm starving. Could you purlease bring me a fish?");
 
         add("mobgroup.minecraft.skeletons", "Skeletons");
         add("modifier_effect.wotr.ability", "Cast %s when %s");

--- a/src/main/java/com/wanderersoftherift/wotr/entity/npc/MobInteraction.java
+++ b/src/main/java/com/wanderersoftherift/wotr/entity/npc/MobInteraction.java
@@ -1,0 +1,23 @@
+package com.wanderersoftherift.wotr.entity.npc;
+
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.MapCodec;
+import com.wanderersoftherift.wotr.init.WotrRegistries;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.InteractionResult;
+import net.minecraft.world.entity.Mob;
+import net.minecraft.world.entity.player.Player;
+
+import java.util.function.Function;
+
+/**
+ * Interface for attachments providing mob interactions for any mob
+ */
+public interface MobInteraction {
+    Codec<MobInteraction> DIRECT_CODEC = WotrRegistries.MOB_INTERACTIONS.byNameCodec()
+            .dispatch(MobInteraction::getCodec, Function.identity());
+
+    MapCodec<? extends MobInteraction> getCodec();
+
+    InteractionResult interact(Mob mob, Player player, InteractionHand hand);
+}

--- a/src/main/java/com/wanderersoftherift/wotr/entity/npc/NoInteract.java
+++ b/src/main/java/com/wanderersoftherift/wotr/entity/npc/NoInteract.java
@@ -1,0 +1,29 @@
+package com.wanderersoftherift.wotr.entity.npc;
+
+import com.mojang.serialization.MapCodec;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.InteractionResult;
+import net.minecraft.world.entity.Mob;
+import net.minecraft.world.entity.player.Player;
+
+/**
+ * No-op mob interaction attachment
+ */
+public final class NoInteract implements MobInteraction {
+
+    public static final NoInteract INSTANCE = new NoInteract();
+    public static final MapCodec<NoInteract> CODEC = MapCodec.unit(INSTANCE);
+
+    private NoInteract() {
+    }
+
+    @Override
+    public MapCodec<? extends MobInteraction> getCodec() {
+        return CODEC;
+    }
+
+    @Override
+    public InteractionResult interact(Mob mob, Player player, InteractionHand hand) {
+        return InteractionResult.PASS;
+    }
+}

--- a/src/main/java/com/wanderersoftherift/wotr/entity/npc/QuestGiverInteract.java
+++ b/src/main/java/com/wanderersoftherift/wotr/entity/npc/QuestGiverInteract.java
@@ -1,22 +1,29 @@
 package com.wanderersoftherift.wotr.entity.npc;
 
+import com.mojang.serialization.Codec;
 import com.mojang.serialization.MapCodec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import com.wanderersoftherift.wotr.core.quest.Quest;
 import com.wanderersoftherift.wotr.core.quest.QuestMenuHelper;
+import com.wanderersoftherift.wotr.init.WotrRegistries;
+import com.wanderersoftherift.wotr.util.HolderSetUtil;
+import net.minecraft.core.HolderSet;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.Mob;
 import net.minecraft.world.entity.player.Player;
 
+import java.util.Optional;
+
 /**
  * MobInteraction attachment for providing Quest Giver behavior
  */
-public final class QuestGiverInteract implements MobInteraction {
-    public static final QuestGiverInteract INSTANCE = new QuestGiverInteract();
-    public static final MapCodec<QuestGiverInteract> CODEC = MapCodec.unit(INSTANCE);
-
-    private QuestGiverInteract() {
-    }
+public record QuestGiverInteract(Optional<HolderSet<Quest>> quests, int choiceCount) implements MobInteraction {
+    public static final MapCodec<QuestGiverInteract> CODEC = RecordCodecBuilder.mapCodec(instance -> instance.group(
+            Quest.SET_CODEC.optionalFieldOf("quests").forGetter(QuestGiverInteract::quests),
+            Codec.INT.optionalFieldOf("choice_count", 5).forGetter(QuestGiverInteract::choiceCount)
+    ).apply(instance, QuestGiverInteract::new));
 
     @Override
     public MapCodec<? extends MobInteraction> getCodec() {
@@ -33,7 +40,9 @@ public final class QuestGiverInteract implements MobInteraction {
             return InteractionResult.SUCCESS;
         }
 
-        QuestMenuHelper.openQuestMenu(serverPlayer, mob);
+        HolderSet<Quest> choices = quests.orElse(
+                HolderSetUtil.registryToHolderSet(serverPlayer.level().registryAccess(), WotrRegistries.Keys.QUESTS));
+        QuestMenuHelper.openQuestMenu(serverPlayer, mob, choices, choiceCount);
         return InteractionResult.CONSUME;
     }
 }

--- a/src/main/java/com/wanderersoftherift/wotr/entity/npc/QuestGiverInteract.java
+++ b/src/main/java/com/wanderersoftherift/wotr/entity/npc/QuestGiverInteract.java
@@ -1,0 +1,39 @@
+package com.wanderersoftherift.wotr.entity.npc;
+
+import com.mojang.serialization.MapCodec;
+import com.wanderersoftherift.wotr.core.quest.QuestMenuHelper;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.InteractionResult;
+import net.minecraft.world.entity.Mob;
+import net.minecraft.world.entity.player.Player;
+
+/**
+ * MobInteraction attachment for providing Quest Giver behavior
+ */
+public final class QuestGiverInteract implements MobInteraction {
+    public static final QuestGiverInteract INSTANCE = new QuestGiverInteract();
+    public static final MapCodec<QuestGiverInteract> CODEC = MapCodec.unit(INSTANCE);
+
+    private QuestGiverInteract() {
+    }
+
+    @Override
+    public MapCodec<? extends MobInteraction> getCodec() {
+        return CODEC;
+    }
+
+    @Override
+    public InteractionResult interact(Mob mob, Player player, InteractionHand hand) {
+        if (player.isCrouching()) {
+            return InteractionResult.PASS;
+        }
+
+        if (!(player instanceof ServerPlayer serverPlayer)) {
+            return InteractionResult.SUCCESS;
+        }
+
+        QuestMenuHelper.openQuestMenu(serverPlayer, mob);
+        return InteractionResult.CONSUME;
+    }
+}

--- a/src/main/java/com/wanderersoftherift/wotr/gui/menu/ValidatingLevelAccess.java
+++ b/src/main/java/com/wanderersoftherift/wotr/gui/menu/ValidatingLevelAccess.java
@@ -61,7 +61,7 @@ public interface ValidatingLevelAccess extends ContainerLevelAccess {
 
             @Override
             public boolean isValid(Player player) {
-                return evaluate((l, pos) -> !entity.isRemoved() && player.distanceTo(entity) < 5.0, true);
+                return evaluate((l, pos) -> !entity.isRemoved() && player.canInteractWithEntity(entity, 5.0), true);
             }
         };
     }

--- a/src/main/java/com/wanderersoftherift/wotr/gui/menu/ValidatingLevelAccess.java
+++ b/src/main/java/com/wanderersoftherift/wotr/gui/menu/ValidatingLevelAccess.java
@@ -1,0 +1,68 @@
+package com.wanderersoftherift.wotr.gui.menu;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.inventory.ContainerLevelAccess;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.Block;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Optional;
+import java.util.function.BiFunction;
+
+/**
+ * Extended ContainerLevelAccess that contains the logic for checking if the menu should still be valid based on its
+ * source
+ */
+public interface ValidatingLevelAccess extends ContainerLevelAccess {
+    ValidatingLevelAccess NULL = new ValidatingLevelAccess() {
+        @Override
+        public <T> @NotNull Optional<T> evaluate(@NotNull BiFunction<Level, BlockPos, T> levelPosConsumer) {
+            return Optional.empty();
+        }
+    };
+
+    default boolean isValid(Player player) {
+        return evaluate((level, pos) -> player.canInteractWithBlock(pos, 4.0), true);
+    }
+
+    /**
+     * @param level
+     * @param blockPos
+     * @param block
+     * @return A validating level access tied to a block
+     */
+    static ValidatingLevelAccess create(final Level level, final BlockPos blockPos, Block block) {
+        return new ValidatingLevelAccess() {
+            @Override
+            public <T> @NotNull Optional<T> evaluate(@NotNull BiFunction<Level, BlockPos, T> levelPosConsumer) {
+                return Optional.of(levelPosConsumer.apply(level, blockPos));
+            }
+
+            @Override
+            public boolean isValid(Player player) {
+                return evaluate((l, pos) -> l.getBlockState(pos).is(block) && player.canInteractWithBlock(pos, 4.0),
+                        true);
+            }
+        };
+    }
+
+    /**
+     * @param entity
+     * @return A validating level access tied to an entity
+     */
+    static ValidatingLevelAccess create(final Entity entity) {
+        return new ValidatingLevelAccess() {
+            @Override
+            public <T> @NotNull Optional<T> evaluate(@NotNull BiFunction<Level, BlockPos, T> levelPosConsumer) {
+                return Optional.of(levelPosConsumer.apply(entity.level(), entity.blockPosition()));
+            }
+
+            @Override
+            public boolean isValid(Player player) {
+                return evaluate((l, pos) -> !entity.isRemoved() && player.distanceTo(entity) < 5.0, true);
+            }
+        };
+    }
+}

--- a/src/main/java/com/wanderersoftherift/wotr/gui/menu/quest/QuestCompletionMenu.java
+++ b/src/main/java/com/wanderersoftherift/wotr/gui/menu/quest/QuestCompletionMenu.java
@@ -6,9 +6,9 @@ import com.wanderersoftherift.wotr.core.quest.QuestState;
 import com.wanderersoftherift.wotr.core.quest.Reward;
 import com.wanderersoftherift.wotr.core.quest.goal.GiveItemGoal;
 import com.wanderersoftherift.wotr.gui.menu.QuickMover;
+import com.wanderersoftherift.wotr.gui.menu.ValidatingLevelAccess;
 import com.wanderersoftherift.wotr.gui.menu.slot.UUIDDataSlot;
 import com.wanderersoftherift.wotr.init.WotrAttachments;
-import com.wanderersoftherift.wotr.init.WotrBlocks;
 import com.wanderersoftherift.wotr.init.WotrMenuTypes;
 import com.wanderersoftherift.wotr.item.handler.QuestItemStackHandler;
 import com.wanderersoftherift.wotr.network.quest.QuestRewardsPayload;
@@ -52,18 +52,18 @@ public class QuestCompletionMenu extends AbstractContainerMenu {
             .tryMoveToPlayer()
             .build();
 
-    private final ContainerLevelAccess access;
+    private final ValidatingLevelAccess access;
     private final ItemStackHandler handInItems;
     private final ActiveQuests quests;
 
     private final UUIDDataSlot selectedQuest = new UUIDDataSlot();
 
     public QuestCompletionMenu(int containerId, Inventory playerInventory) {
-        this(containerId, playerInventory, ContainerLevelAccess.NULL,
+        this(containerId, playerInventory, ValidatingLevelAccess.NULL,
                 Minecraft.getInstance().player.getData(WotrAttachments.ACTIVE_QUESTS), null);
     }
 
-    public QuestCompletionMenu(int containerId, Inventory playerInventory, ContainerLevelAccess access,
+    public QuestCompletionMenu(int containerId, Inventory playerInventory, ValidatingLevelAccess access,
             ActiveQuests activeQuests, UUID selected) {
         super(WotrMenuTypes.QUEST_COMPLETION_MENU.get(), containerId);
 
@@ -89,7 +89,7 @@ public class QuestCompletionMenu extends AbstractContainerMenu {
 
     @Override
     public boolean stillValid(@NotNull Player player) {
-        return stillValid(this.access, player, WotrBlocks.QUEST_HUB.get());
+        return access.isValid(player);
     }
 
     public Optional<QuestState> getQuestState() {

--- a/src/main/java/com/wanderersoftherift/wotr/gui/menu/quest/QuestGiverMenu.java
+++ b/src/main/java/com/wanderersoftherift/wotr/gui/menu/quest/QuestGiverMenu.java
@@ -2,14 +2,13 @@ package com.wanderersoftherift.wotr.gui.menu.quest;
 
 import com.wanderersoftherift.wotr.core.quest.ActiveQuests;
 import com.wanderersoftherift.wotr.core.quest.QuestState;
+import com.wanderersoftherift.wotr.gui.menu.ValidatingLevelAccess;
 import com.wanderersoftherift.wotr.init.WotrAttachments;
-import com.wanderersoftherift.wotr.init.WotrBlocks;
 import com.wanderersoftherift.wotr.init.WotrMenuTypes;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.AbstractContainerMenu;
-import net.minecraft.world.inventory.ContainerLevelAccess;
 import net.minecraft.world.item.ItemStack;
 import org.jetbrains.annotations.NotNull;
 
@@ -21,15 +20,15 @@ import java.util.List;
  * menu.
  */
 public class QuestGiverMenu extends AbstractContainerMenu {
-    private final ContainerLevelAccess access;
+    private final ValidatingLevelAccess access;
     private final List<QuestState> availableQuests;
     private boolean availableQuestsDirty = false;
 
     public QuestGiverMenu(int containerId, Inventory playerInventory) {
-        this(containerId, playerInventory, ContainerLevelAccess.NULL, new ArrayList<>());
+        this(containerId, playerInventory, ValidatingLevelAccess.NULL, new ArrayList<>());
     }
 
-    public QuestGiverMenu(int containerId, Inventory playerInventory, ContainerLevelAccess access,
+    public QuestGiverMenu(int containerId, Inventory playerInventory, ValidatingLevelAccess access,
             List<QuestState> availableQuests) {
         super(WotrMenuTypes.QUEST_GIVER_MENU.get(), containerId);
 
@@ -48,7 +47,7 @@ public class QuestGiverMenu extends AbstractContainerMenu {
 
     @Override
     public boolean stillValid(@NotNull Player player) {
-        return stillValid(this.access, player, WotrBlocks.QUEST_HUB.get());
+        return access.isValid(player);
     }
 
     public void acceptQuest(ServerPlayer player, int index) {

--- a/src/main/java/com/wanderersoftherift/wotr/init/WotrAttachments.java
+++ b/src/main/java/com/wanderersoftherift/wotr/init/WotrAttachments.java
@@ -16,6 +16,8 @@ import com.wanderersoftherift.wotr.core.guild.currency.Wallet;
 import com.wanderersoftherift.wotr.core.quest.ActiveQuests;
 import com.wanderersoftherift.wotr.core.quest.QuestState;
 import com.wanderersoftherift.wotr.core.rift.RiftEntryState;
+import com.wanderersoftherift.wotr.entity.npc.MobInteraction;
+import com.wanderersoftherift.wotr.entity.npc.NoInteract;
 import com.wanderersoftherift.wotr.entity.player.PrimaryStatistics;
 import com.wanderersoftherift.wotr.entity.portal.RiftEntrance;
 import com.wanderersoftherift.wotr.init.ability.WotrTrackedAbilityTriggers;
@@ -109,6 +111,13 @@ public class WotrAttachments {
                     .serialize(ActiveQuests.getSerializer())
                     .copyOnDeath()
                     .build());
+
+    public static final Supplier<AttachmentType<MobInteraction>> MOB_INTERACT = ATTACHMENT_TYPES.register(
+            "mob_interact",
+            () -> AttachmentType.<MobInteraction>builder(() -> NoInteract.INSTANCE)
+                    .serialize(MobInteraction.DIRECT_CODEC)
+                    .build()
+    );
 
     /// Player progression
     public static final Supplier<AttachmentType<PrimaryStatistics>> PRIMARY_STATISTICS = ATTACHMENT_TYPES.register(

--- a/src/main/java/com/wanderersoftherift/wotr/init/WotrMobInteractions.java
+++ b/src/main/java/com/wanderersoftherift/wotr/init/WotrMobInteractions.java
@@ -1,0 +1,23 @@
+package com.wanderersoftherift.wotr.init;
+
+import com.mojang.serialization.MapCodec;
+import com.wanderersoftherift.wotr.WanderersOfTheRift;
+import com.wanderersoftherift.wotr.entity.npc.MobInteraction;
+import com.wanderersoftherift.wotr.entity.npc.NoInteract;
+import com.wanderersoftherift.wotr.entity.npc.QuestGiverInteract;
+import net.neoforged.neoforge.registries.DeferredRegister;
+
+import java.util.function.Supplier;
+
+public class WotrMobInteractions {
+
+    public static final DeferredRegister<MapCodec<? extends MobInteraction>> MOB_INTERACTIONS = DeferredRegister
+            .create(WotrRegistries.Keys.MOB_INTERACTIONS, WanderersOfTheRift.MODID);
+
+    public static final Supplier<MapCodec<? extends MobInteraction>> NONE = MOB_INTERACTIONS.register("none",
+            () -> NoInteract.CODEC);
+
+    public static final Supplier<MapCodec<? extends MobInteraction>> QUEST_GIVER = MOB_INTERACTIONS
+            .register("quest_giver", () -> QuestGiverInteract.CODEC);
+
+}

--- a/src/main/java/com/wanderersoftherift/wotr/init/WotrRegistries.java
+++ b/src/main/java/com/wanderersoftherift/wotr/init/WotrRegistries.java
@@ -21,6 +21,7 @@ import com.wanderersoftherift.wotr.core.quest.RewardProvider;
 import com.wanderersoftherift.wotr.core.rift.RiftConfigDataType;
 import com.wanderersoftherift.wotr.core.rift.RiftGenerationConfig;
 import com.wanderersoftherift.wotr.entity.mob.MobVariantData;
+import com.wanderersoftherift.wotr.entity.npc.MobInteraction;
 import com.wanderersoftherift.wotr.entity.player.PrimaryStatistic;
 import com.wanderersoftherift.wotr.gui.menu.character.CharacterMenuItem;
 import com.wanderersoftherift.wotr.item.implicit.ImplicitConfig;
@@ -91,6 +92,8 @@ public class WotrRegistries {
     public static final Registry<DualCodec<? extends Reward>> REWARD_TYPES = new RegistryBuilder<>(Keys.REWARD_TYPES)
             .sync(true)
             .create();
+    public static final Registry<MapCodec<? extends MobInteraction>> MOB_INTERACTIONS = new RegistryBuilder<>(
+            Keys.MOB_INTERACTIONS).create();
     public static final Registry<MapCodec<? extends RiftLayout.Factory>> LAYOUT_TYPES = new RegistryBuilder<>(
             Keys.LAYOUT_TYPES).create();
     public static final Registry<MapCodec<? extends LayeredRiftLayout.LayoutLayer.Factory>> LAYOUT_LAYER_TYPES = new RegistryBuilder<>(
@@ -175,6 +178,7 @@ public class WotrRegistries {
         public static final ResourceKey<Registry<TrackedAbilityTrigger.TriggerType<?>>> TRACKED_ABILITY_TRIGGERS = ResourceKey
                 .createRegistryKey(WanderersOfTheRift.id("tracked_ability_activation"));
 
+        // Quests
         public static final ResourceKey<Registry<Quest>> QUESTS = ResourceKey
                 .createRegistryKey(WanderersOfTheRift.id("quest"));
         public static final ResourceKey<Registry<MapCodec<? extends GoalProvider>>> GOAL_PROVIDER_TYPES = ResourceKey
@@ -214,6 +218,10 @@ public class WotrRegistries {
         public static final ResourceKey<Registry<DualCodec<? extends ModifierSource>>> MODIFIER_SOURCES = ResourceKey
                 .createRegistryKey(WanderersOfTheRift.id("modifier_source"));
 
+        // Mobs
+        public static final ResourceKey<Registry<MapCodec<? extends MobInteraction>>> MOB_INTERACTIONS = ResourceKey
+                .createRegistryKey(WanderersOfTheRift.id("mob_interactions"));
+
         private Keys() {
         }
     }
@@ -236,6 +244,7 @@ public class WotrRegistries {
         event.register(GOAL_TYPES);
         event.register(REWARD_PROVIDER_TYPES);
         event.register(REWARD_TYPES);
+        event.register(MOB_INTERACTIONS);
         event.register(EDIT_TYPES);
         event.register(TRACKED_ABILITY_TRIGGERS);
         event.register(ABILITY_SOURCES);

--- a/src/main/java/com/wanderersoftherift/wotr/mixin/MixinMob.java
+++ b/src/main/java/com/wanderersoftherift/wotr/mixin/MixinMob.java
@@ -1,0 +1,34 @@
+package com.wanderersoftherift.wotr.mixin;
+
+import com.wanderersoftherift.wotr.init.WotrAttachments;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.InteractionResult;
+import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.Mob;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.level.Level;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(Mob.class)
+public abstract class MixinMob extends LivingEntity {
+    protected MixinMob(EntityType<? extends LivingEntity> type, Level level) {
+        super(type, level);
+    }
+
+    @Inject(method = "mobInteract", at = @At(value = "RETURN"), cancellable = true)
+    protected void wotrMobInteractExtension(
+            Player player,
+            InteractionHand hand,
+            CallbackInfoReturnable<InteractionResult> cir) {
+        if (cir.getReturnValue() == InteractionResult.PASS) {
+            this.getExistingData(WotrAttachments.MOB_INTERACT)
+                    .ifPresent(data -> cir.setReturnValue(data.interact((Mob) (LivingEntity) this, player, hand)));
+
+        }
+    }
+
+}

--- a/src/main/java/com/wanderersoftherift/wotr/util/HolderSetUtil.java
+++ b/src/main/java/com/wanderersoftherift/wotr/util/HolderSetUtil.java
@@ -1,0 +1,21 @@
+package com.wanderersoftherift.wotr.util;
+
+import com.google.common.collect.ImmutableList;
+import net.minecraft.core.HolderSet;
+import net.minecraft.core.Registry;
+import net.minecraft.core.RegistryAccess;
+import net.minecraft.resources.ResourceKey;
+
+public final class HolderSetUtil {
+
+    private HolderSetUtil() {
+    }
+
+    public static <T> HolderSet<T> registryToHolderSet(Registry<T> registry) {
+        return HolderSet.direct(ImmutableList.copyOf(registry.asHolderIdMap()));
+    }
+
+    public static <T> HolderSet<T> registryToHolderSet(RegistryAccess registryAccess, ResourceKey<Registry<T>> key) {
+        return registryToHolderSet(registryAccess.lookupOrThrow(key));
+    }
+}

--- a/src/main/resources/data/wotr/tags/wotr/quest/feline.json
+++ b/src/main/resources/data/wotr/tags/wotr/quest/feline.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "wotr:bring_fish"
+  ]
+}

--- a/src/main/resources/data/wotr/tags/wotr/quest/hub.json
+++ b/src/main/resources/data/wotr/tags/wotr/quest/hub.json
@@ -1,0 +1,9 @@
+{
+  "values": [
+    "wotr:complete_rift",
+    "wotr:fetch_quest",
+    "wotr:gold_and_iron",
+    "wotr:kill_skeletons",
+    "wotr:skillthread"
+  ]
+}

--- a/src/main/resources/data/wotr/wotr/quest/bring_fish.json
+++ b/src/main/resources/data/wotr/wotr/quest/bring_fish.json
@@ -1,0 +1,18 @@
+{
+  "goals": [
+    {
+      "type": "wotr:give_item",
+      "item" : "#c:foods/raw_fish",
+      "count": 1
+    }
+  ],
+  "rewards": [
+    {
+      "type": "wotr:item",
+      "item": {
+        "count": 1,
+        "id": "minecraft:gold_ingot"
+      }
+    }
+  ]
+}

--- a/src/main/resources/wotr.mixins.json
+++ b/src/main/resources/wotr.mixins.json
@@ -24,6 +24,7 @@
         "MixinJigsawReplacementProcessor",
         "MixinLavaFluid",
         "MixinLivingEntity",
+        "MixinMob",
         "MixinOctahedralGroup",
         "MixinProtoChunk",
         "MixinRegionFileVersion",


### PR DESCRIPTION
This PR introduce a MobInteraction attachment, which provides an extension point for altering Mob behavior when the player interacts. This is used to allow any mob to be made a quest giver.

Additionally introduces ValidatingLevelAccess as an extension off of ContainerLevelAccess, moving the stillValid check for menus into this type - this allows the same menu to be opened by different sources and check correctly if the menu should remain open (e.g. if the QuestHub block is still present and near the player, or if the quest giver Mob is alive and nearby)

Testing

Added a `wotr debug makeQuestGiver <entityId>` command. Can be tested by looking an mob and using tab completion to get its id.

Closes #298 