### PR TITLE
fix: #357 do not apply difficult changes to mobs being loaded from disk

### DIFF
--- a/src/main/java/com/wanderersoftherift/wotr/rift/RiftDifficultyEvents.java
+++ b/src/main/java/com/wanderersoftherift/wotr/rift/RiftDifficultyEvents.java
@@ -20,7 +20,7 @@ public class RiftDifficultyEvents {
 
     @SubscribeEvent
     public static void onEntitySpawned(EntityJoinLevelEvent event) {
-        if (event.getLevel().isClientSide() || event.getEntity() instanceof Player) {
+        if (event.getLevel().isClientSide() || event.getEntity() instanceof Player || event.loadedFromDisk()) {
             return;
         }
         if (event.getLevel() instanceof ServerLevel serverLevel && RiftLevelManager.isRift(serverLevel)


### PR DESCRIPTION
Prevents mobs having difficulty increases applied multiple times and having health reset on load.