### PR TITLE
Enchantments modifiers

### DIFF
--- a/src/main/java/com/wanderersoftherift/wotr/init/WotrModifierEffectTypes.java
+++ b/src/main/java/com/wanderersoftherift/wotr/init/WotrModifierEffectTypes.java
@@ -4,6 +4,7 @@ import com.mojang.serialization.MapCodec;
 import com.wanderersoftherift.wotr.WanderersOfTheRift;
 import com.wanderersoftherift.wotr.item.ability.AbilityModifier;
 import com.wanderersoftherift.wotr.modifier.effect.AttributeModifierEffect;
+import com.wanderersoftherift.wotr.modifier.effect.EnchantmentModifierEffect;
 import com.wanderersoftherift.wotr.modifier.effect.EnhanceAbilityModifierEffect;
 import com.wanderersoftherift.wotr.modifier.effect.ModifierEffect;
 import com.wanderersoftherift.wotr.modifier.effect.ProvideAbilityConditionModifierEffect;
@@ -26,4 +27,6 @@ public class WotrModifierEffectTypes {
             .register("ability_enhancement", () -> EnhanceAbilityModifierEffect.MODIFIER_CODEC);
     public static final Supplier<MapCodec<? extends ModifierEffect>> ABILITY_CONDITIONING_MODIFIER = MODIFIER_EFFECT_TYPES
             .register("ability_condition", () -> ProvideAbilityConditionModifierEffect.MODIFIER_CODEC);
+    public static final Supplier<MapCodec<? extends ModifierEffect>> ENCHANT_MODIFIER = MODIFIER_EFFECT_TYPES
+            .register("enchant", () -> EnchantmentModifierEffect.CODEC);
 }

--- a/src/main/java/com/wanderersoftherift/wotr/item/implicit/GearImplicits.java
+++ b/src/main/java/com/wanderersoftherift/wotr/item/implicit/GearImplicits.java
@@ -40,7 +40,7 @@ public interface GearImplicits extends ModifierProvider {
 
     @Override
     default void forEachModifier(ItemStack stack, WotrEquipmentSlot slot, LivingEntity entity, Action action) {
-        List<ModifierInstance> modifierInstances = modifierInstances(stack, entity.level());
+        List<ModifierInstance> modifierInstances = modifierInstances(stack, entity == null ? null : entity.level());
         for (int i = 0; i < modifierInstances.size(); i++) {
             ModifierInstance modifier = modifierInstances.get(i);
             ModifierSource source = new GearImplicitModifierSource(slot, i);

--- a/src/main/java/com/wanderersoftherift/wotr/item/implicit/UnrolledGearImplicits.java
+++ b/src/main/java/com/wanderersoftherift/wotr/item/implicit/UnrolledGearImplicits.java
@@ -19,7 +19,7 @@ public record UnrolledGearImplicits() implements GearImplicits {
 
     @Override
     public List<ModifierInstance> modifierInstances(ItemStack stack, Level level) {
-        if (level.isClientSide()) {
+        if (level == null || level.isClientSide()) {
             return List.of();
         }
         Registry<ImplicitConfig> implicitConfigs = level.registryAccess().lookupOrThrow(GEAR_IMPLICITS_CONFIG);

--- a/src/main/java/com/wanderersoftherift/wotr/modifier/ModifierEventHandler.java
+++ b/src/main/java/com/wanderersoftherift/wotr/modifier/ModifierEventHandler.java
@@ -3,16 +3,38 @@ package com.wanderersoftherift.wotr.modifier;
 import com.wanderersoftherift.wotr.WanderersOfTheRift;
 import com.wanderersoftherift.wotr.core.inventory.slot.WotrEquipmentSlot;
 import com.wanderersoftherift.wotr.core.inventory.slot.WotrEquipmentSlotEvent;
+import com.wanderersoftherift.wotr.modifier.effect.EnchantmentModifierEffect;
+import net.minecraft.resources.ResourceKey;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.enchantment.Enchantment;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
+import net.neoforged.neoforge.event.enchanting.GetEnchantmentLevelEvent;
 
 /**
  * Handles events to trigger modifier updates
  */
 @EventBusSubscriber(modid = WanderersOfTheRift.MODID, bus = EventBusSubscriber.Bus.GAME)
 public class ModifierEventHandler {
+
+    @SubscribeEvent
+    private static void addEnchants(GetEnchantmentLevelEvent event) {
+        var enchants = event.getEnchantments();
+        var enchantsLookup = event.getLookup();
+        visitItemModifierProviders(event.getStack(), null, null, (modifierHolder, tier, roll, source) -> {
+            modifierHolder.value().getModifierTier(tier).forEach(it -> {
+                if (!(it instanceof EnchantmentModifierEffect(ResourceKey<Enchantment> enchant, int level))) {
+                    return;
+                }
+                var current = enchantsLookup.get(enchant);
+                if (current.isEmpty()) {
+                    return;
+                }
+                enchants.set(current.get(), enchants.getLevel(current.get()) + level);
+            });
+        });
+    }
 
     @SubscribeEvent
     public static void onSlotChanged(WotrEquipmentSlotEvent.Changed event) {

--- a/src/main/java/com/wanderersoftherift/wotr/modifier/effect/EnchantmentModifierEffect.java
+++ b/src/main/java/com/wanderersoftherift/wotr/modifier/effect/EnchantmentModifierEffect.java
@@ -1,0 +1,55 @@
+package com.wanderersoftherift.wotr.modifier.effect;
+
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.MapCodec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import com.wanderersoftherift.wotr.client.tooltip.ImageComponent;
+import com.wanderersoftherift.wotr.modifier.source.ModifierSource;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.Style;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.enchantment.Enchantment;
+
+import java.util.List;
+
+public record EnchantmentModifierEffect(ResourceKey<Enchantment> enchant, int level) implements ModifierEffect {
+
+    public static final MapCodec<EnchantmentModifierEffect> CODEC = RecordCodecBuilder.mapCodec(
+            instance -> instance.group(
+                    ResourceKey.codec(Registries.ENCHANTMENT)
+                            .fieldOf("enchant")
+                            .forGetter(EnchantmentModifierEffect::enchant),
+                    Codec.INT.fieldOf("level").forGetter(EnchantmentModifierEffect::level)
+            ).apply(instance, EnchantmentModifierEffect::new)
+    );
+
+    @Override
+    public MapCodec<? extends ModifierEffect> getCodec() {
+        return CODEC;
+    }
+
+    @Override
+    public void enableModifier(double roll, Entity entity, ModifierSource source, int effectIndex) {
+
+    }
+
+    @Override
+    public void disableModifier(double roll, Entity entity, ModifierSource source, int effectIndex) {
+
+    }
+
+    @Override
+    public List<ImageComponent> getTooltipComponent(ItemStack stack, float roll, Style style) {
+        return List.of(new ImageComponent(stack,
+                Component.translatable(enchant().location().toLanguageKey("enchantment")).withColor(0xdddd44), null));
+    }
+
+    @Override
+    public List<ImageComponent> getAdvancedTooltipComponent(ItemStack stack, float roll, Style style, int tier) {
+        return List.of(new ImageComponent(stack,
+                Component.translatable(enchant().location().toLanguageKey("enchantment")).withColor(0xdddd44), null));
+    }
+}

--- a/src/main/resources/data/wotr/wotr/modifier/test_silk_touch.json
+++ b/src/main/resources/data/wotr/wotr/modifier/test_silk_touch.json
@@ -1,0 +1,11 @@
+{
+    "tiers": [
+        [
+            {
+                "type": "wotr:enchant",
+                "enchant": "minecraft:silk_touch",
+                "level": 1
+            }
+        ]
+    ]
+}


### PR DESCRIPTION
Ports enchantments to our modifier system.

There are two versions, so first we should decide which version to use:

Version A (this PR): Uses `GetEnchantmentLevelEvent` to check which modifiers are present on a tool. Advantage: it's really simple. Disadvantage: these modifiers will only work on equipment the enchantments are intended for (e.g. silk touch only works on tools, doesn't work on armor), which contradicts how other modifiers work (attack damage works whether it's on sword, shield or armor)

Version B (the other PR): enchantment modifiers register their enchants to player attachment. Logic using those enchantments is then modified to allow reading from this attachment. Advantage: enchantment modifiers are no longer limited to specific equipment. Disadvantage: this method requires individually adjusting all uses of enchantments - a task of quite unknown magnitude. Currently only ports loot tables. This required 3 mixins and even that might have missed some cases.