### PR TITLE
fix: #390 copy the key when opening a rift

### DIFF
--- a/src/main/java/com/wanderersoftherift/wotr/item/riftkey/RiftKey.java
+++ b/src/main/java/com/wanderersoftherift/wotr/item/riftkey/RiftKey.java
@@ -173,7 +173,7 @@ public class RiftKey extends Item {
         portalEntranceEntity.setPos(pos);
         portalEntranceEntity.setYRot(dir.toYRot());
         portalEntranceEntity.setBillboard(dir.getAxis().isVertical());
-        portalEntranceEntity.setKeyItem(riftKey);
+        portalEntranceEntity.setKeyItem(riftKey.copy());
         level.addFreshEntity(portalEntranceEntity);
         portalEntranceEntity.playSound(WotrSoundEvents.RIFT_OPEN.value());
     }


### PR DESCRIPTION
Closes #390 