### PR TITLE
fix: rift entrance no longer tries to remove itself on the client side

### DIFF
--- a/src/main/java/com/wanderersoftherift/wotr/core/rift/RiftLevelManager.java
+++ b/src/main/java/com/wanderersoftherift/wotr/core/rift/RiftLevelManager.java
@@ -60,6 +60,7 @@ public final class RiftLevelManager {
     /**
      * @param id
      * @return Whether a level with the given id exists
+     * @throws NullPointerException if called from client when connected to a server
      */
     public static boolean levelExists(ResourceKey<Level> id) {
         return levelExists(id.location());

--- a/src/main/java/com/wanderersoftherift/wotr/entity/portal/RiftPortalEntranceEntity.java
+++ b/src/main/java/com/wanderersoftherift/wotr/entity/portal/RiftPortalEntranceEntity.java
@@ -44,7 +44,7 @@ public class RiftPortalEntranceEntity extends RiftPortalEntity {
 
     @Override
     public void tick() {
-        if (entrance().generated() && !levelExists(entrance().target())) {
+        if (!level().isClientSide && entrance().generated() && !levelExists(entrance().target())) {
             this.remove(RemovalReason.DISCARDED);
             return;
         }


### PR DESCRIPTION
closes #398 