### PR TITLE
Fix: correct knockback and knockback heavy modifier usage

### DIFF
--- a/src/main/java/com/wanderersoftherift/wotr/datagen/WotrModifierProvider.java
+++ b/src/main/java/com/wanderersoftherift/wotr/datagen/WotrModifierProvider.java
@@ -210,14 +210,14 @@ public class WotrModifierProvider {
                 Style.EMPTY.withColor(ColorUtil.SKY_BLUE))
         );
         registerModifier(context, getResourceKey("knockback"), new Modifier(
-                generateEqualRollSpread(3,
+                generateEqualRollSpread(5,
                         List.of(new ToBeTieredModifierEffect(0.01F, 7.5F,
                                 attributeModifierEffectGetter(WanderersOfTheRift.id("knockback"),
                                         Attributes.ATTACK_KNOCKBACK, AttributeModifier.Operation.ADD_VALUE)))),
                 Style.EMPTY.withColor(ColorUtil.DARK_ORANGE))
         );
         registerModifier(context, getResourceKey("knockback_heavy"), new Modifier(
-                generateEqualRollSpread(3,
+                generateEqualRollSpread(5,
                         List.of(new ToBeTieredModifierEffect(0.01F, 15F,
                                 attributeModifierEffectGetter(WanderersOfTheRift.id("knockback_heavy"),
                                         Attributes.ATTACK_KNOCKBACK, AttributeModifier.Operation.ADD_VALUE))),

--- a/src/main/java/com/wanderersoftherift/wotr/datagen/WotrRuneGemDataProvider.java
+++ b/src/main/java/com/wanderersoftherift/wotr/datagen/WotrRuneGemDataProvider.java
@@ -825,8 +825,8 @@ public class WotrRuneGemDataProvider {
                                         new TieredModifier(1, getModifier(lookup, "attack_flat")),
                                         new TieredModifier(2, getModifier(lookup, "attack_heavy")),
                                         new TieredModifier(2, getModifier(lookup, "attack_percent")),
-                                        new TieredModifier(1, getModifier(lookup, "knockback")),
-                                        new TieredModifier(1, getModifier(lookup, "knockback_heavy"))
+                                        new TieredModifier(2, getModifier(lookup, "knockback")),
+                                        new TieredModifier(2, getModifier(lookup, "knockback_heavy"))
                                 ))),
                         RunegemTier.CUT));
         registerRunegem(context, getRunegemResourceKey("zombie_shaped"),
@@ -836,8 +836,8 @@ public class WotrRuneGemDataProvider {
                                         new TieredModifier(2, getModifier(lookup, "attack_flat")),
                                         new TieredModifier(2, getModifier(lookup, "attack_heavy")),
                                         new TieredModifier(3, getModifier(lookup, "attack_percent")),
-                                        new TieredModifier(1, getModifier(lookup, "knockback")),
-                                        new TieredModifier(1, getModifier(lookup, "knockback_heavy"))
+                                        new TieredModifier(3, getModifier(lookup, "knockback")),
+                                        new TieredModifier(3, getModifier(lookup, "knockback_heavy"))
                                 ))),
                         RunegemTier.SHAPED));
         registerRunegem(context, getRunegemResourceKey("zombie_polished"),
@@ -847,8 +847,8 @@ public class WotrRuneGemDataProvider {
                                         new TieredModifier(3, getModifier(lookup, "attack_flat")),
                                         new TieredModifier(3, getModifier(lookup, "attack_heavy")),
                                         new TieredModifier(4, getModifier(lookup, "attack_percent")),
-                                        new TieredModifier(2, getModifier(lookup, "knockback")),
-                                        new TieredModifier(2, getModifier(lookup, "knockback_heavy"))
+                                        new TieredModifier(4, getModifier(lookup, "knockback")),
+                                        new TieredModifier(3, getModifier(lookup, "knockback_heavy"))
                                 ))),
                         RunegemTier.POLISHED));
         registerRunegem(context, getRunegemResourceKey("zombie_framed"),
@@ -858,8 +858,8 @@ public class WotrRuneGemDataProvider {
                                         new TieredModifier(4, getModifier(lookup, "attack_flat")),
                                         new TieredModifier(4, getModifier(lookup, "attack_heavy")),
                                         new TieredModifier(5, getModifier(lookup, "attack_percent")),
-                                        new TieredModifier(3, getModifier(lookup, "knockback")),
-                                        new TieredModifier(2, getModifier(lookup, "knockback_heavy"))
+                                        new TieredModifier(5, getModifier(lookup, "knockback")),
+                                        new TieredModifier(4, getModifier(lookup, "knockback_heavy"))
                                 ))),
                         RunegemTier.FRAMED));
     }


### PR DESCRIPTION
Changed knockback and knockback heavy to be 5 tiers instead of 3 as 4 and 5 were rolling on high tier attack runegems, causing a crash with the tooltip. Also extended zombie gem for more tier usage of these modifiers.