### PR TITLE
Remove enchantments from trades, mob drops, and other sources

### DIFF
--- a/src/main/resources/data/minecraft/tags/enchantment/in_enchanting_table.json
+++ b/src/main/resources/data/minecraft/tags/enchantment/in_enchanting_table.json
@@ -1,0 +1,4 @@
+{
+  "values" : [],
+  "replace": true
+}

--- a/src/main/resources/data/minecraft/tags/enchantment/on_mob_spawn_equipment.json
+++ b/src/main/resources/data/minecraft/tags/enchantment/on_mob_spawn_equipment.json
@@ -1,0 +1,4 @@
+{
+  "values" : [],
+  "replace": true
+}

--- a/src/main/resources/data/minecraft/tags/enchantment/on_random_loot.json
+++ b/src/main/resources/data/minecraft/tags/enchantment/on_random_loot.json
@@ -1,0 +1,4 @@
+{
+  "values" : [],
+  "replace": true
+}

--- a/src/main/resources/data/minecraft/tags/enchantment/on_traded_equipment.json
+++ b/src/main/resources/data/minecraft/tags/enchantment/on_traded_equipment.json
@@ -1,0 +1,4 @@
+{
+  "values" : [],
+  "replace": true
+}

--- a/src/main/resources/data/minecraft/tags/enchantment/tradeable.json
+++ b/src/main/resources/data/minecraft/tags/enchantment/tradeable.json
@@ -1,0 +1,4 @@
+{
+  "values" : [],
+  "replace": true
+}

--- a/src/main/resources/data/wotr/loot_modifiers/remove_enchants_from_loot.json
+++ b/src/main/resources/data/wotr/loot_modifiers/remove_enchants_from_loot.json
@@ -1,26 +1,5 @@
 {
   "type": "wotr:remove_enchants_from_loot",
   "conditions": [
-    {
-      "condition": "minecraft:any_of",
-      "terms": [
-        {
-          "condition": "wotr:partial_loot_table_id",
-          "path": "chests/"
-        },
-        {
-          "condition": "wotr:partial_loot_table_id",
-          "path": "equipment/"
-        },
-        {
-          "condition": "wotr:partial_loot_table_id",
-          "path": "spawners/"
-        },
-        {
-          "condition": "wotr:partial_loot_table_id",
-          "path": "gameplay/"
-        }
-      ]
-    }
   ]
 }


### PR DESCRIPTION
Closes #197 
Clears a number of core Minecraft enchantment tags to prevent them villagers offering enchantments, mobs dropping them, and similar.