### PR TITLE
Fix chest rendering

### DIFF
--- a/src/main/resources/assets/wotr/models/block/rift_chest.json
+++ b/src/main/resources/assets/wotr/models/block/rift_chest.json
@@ -1,5 +1,6 @@
 {
   "parent": "block/block",
+  "render_type": "minecraft:cutout",
   "credit": "Made with Blockbench",
   "texture_size": [
     128,

--- a/src/main/resources/assets/wotr/models/block/rift_chest_left.json
+++ b/src/main/resources/assets/wotr/models/block/rift_chest_left.json
@@ -1,5 +1,6 @@
 {
 	"parent": "minecraft:block/block",
+	"render_type": "minecraft:cutout",
 	"format_version": "1.21.6",
 	"credit": "Made with Blockbench",
 	"texture_size": [128, 128],

--- a/src/main/resources/assets/wotr/models/block/rift_chest_right.json
+++ b/src/main/resources/assets/wotr/models/block/rift_chest_right.json
@@ -1,5 +1,6 @@
 {
 	"parent": "minecraft:block/block",
+	"render_type": "minecraft:cutout",
 	"format_version": "1.21.6",
 	"credit": "Made with Blockbench",
 	"texture_size": [128, 128],


### PR DESCRIPTION
Closes #491 
Sets rift chests to render with the cutout render type to allow for transparent pixels in the texture.