### PR TITLE
Add: Discount Hookshot

### DIFF
--- a/src/main/resources/data/wotr/wotr/abilities/hookpull.json
+++ b/src/main/resources/data/wotr/wotr/abilities/hookpull.json
@@ -1,0 +1,82 @@
+{
+  "type": "wotr:persistent",
+  "icon" : "minecraft:textures/block/brown_mushroom.png",
+  "requirements" : [
+    {
+      "type": "wotr:cooldown",
+      "ticks": 40
+    }
+  ],
+  "ongoing_requirements": [
+    {
+      "type": "wotr:own_attached_effect",
+      "id": "grab"
+    }
+  ],
+  "mana_cost": 1,
+    "activation_effects": [
+      {
+        "type": "wotr:attach",
+        "id": "grab",
+        "trigger": {
+          "frequency": 1
+        },
+        "continue": {
+          "duration": 16
+        },
+        "effects": [
+          {
+            "type": "wotr:targeting",
+            "targeting": {
+              "type": "wotr:raycast",
+              "range": 200
+            },
+            "effects": [
+              {
+                "type": "wotr:movement",
+                "relative_frame": "source_from_target",
+                "velocity": [
+                  0,
+                  0,
+                  0.2
+                ]
+              },
+              {
+                "type": "wotr:status",
+                "status_effect": {
+                  "id": "minecraft:slowness",
+                  "amplifier": 100,
+                  "duration": 2
+                },
+                "targeting": {
+                  "type": "wotr:caster"
+                }
+              }
+            ]
+          },
+          {
+            "type": "wotr:movement",
+            "relative_frame": "absolute",
+            "velocity": [
+              0,
+              0.02,
+              0
+            ]
+          },
+          {
+            "type": "wotr:movement",
+            "velocity": [
+              0.0,
+              0.0,
+              0.2
+            ]
+          }
+        ]
+      }
+    ],
+  "on_deactivation_effects": [
+    {
+      "type": "wotr:detach_own"
+    }
+  ]
+}


### PR DESCRIPTION
Incomplete hookshot. Should be projectile, and preferably a tether between source and target. When available, stun instead of slow.