### PR TITLE
(#498) AbilityBench drops contents on destroy

### DIFF
--- a/src/main/java/com/wanderersoftherift/wotr/block/AbilityBenchBlock.java
+++ b/src/main/java/com/wanderersoftherift/wotr/block/AbilityBenchBlock.java
@@ -98,4 +98,17 @@ public class AbilityBenchBlock extends BaseEntityBlock {
     public BlockEntity newBlockEntity(@NotNull BlockPos pos, @NotNull BlockState state) {
         return new AbilityBenchBlockEntity(pos, state);
     }
+
+    @Override
+    protected void onRemove(
+            @NotNull BlockState state,
+            @NotNull Level level,
+            @NotNull BlockPos pos,
+            @NotNull BlockState newState,
+            boolean isMoving) {
+        if (!newState.is(state.getBlock()) && level.getBlockEntity(pos) instanceof AbilityBenchBlockEntity entity) {
+            entity.dropContents();
+        }
+        super.onRemove(state, level, pos, newState, isMoving);
+    }
 }

--- a/src/main/java/com/wanderersoftherift/wotr/block/blockentity/AbilityBenchBlockEntity.java
+++ b/src/main/java/com/wanderersoftherift/wotr/block/blockentity/AbilityBenchBlockEntity.java
@@ -8,6 +8,7 @@ import com.wanderersoftherift.wotr.init.WotrItems;
 import com.wanderersoftherift.wotr.item.handler.ChangeAwareItemHandler;
 import com.wanderersoftherift.wotr.item.handler.LargeCountItemHandler;
 import com.wanderersoftherift.wotr.network.ability.AbilitySlotsUpdatePayload;
+import com.wanderersoftherift.wotr.util.ItemStackHandlerUtil;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.nbt.CompoundTag;
@@ -59,6 +60,12 @@ public class AbilityBenchBlockEntity extends BlockEntity {
             }
         };
         return new AbilityBenchMenu(containerId, playerInventory, threadStorage,
-                ContainerLevelAccess.create(level, getBlockPos()), replicatedSlots);
+                ContainerLevelAccess.create(player.level(), getBlockPos()), replicatedSlots);
+    }
+
+    public void dropContents() {
+        if (hasLevel()) {
+            ItemStackHandlerUtil.dropContents(getLevel(), getBlockPos(), threadStorage);
+        }
     }
 }

--- a/src/main/java/com/wanderersoftherift/wotr/util/ItemStackHandlerUtil.java
+++ b/src/main/java/com/wanderersoftherift/wotr/util/ItemStackHandlerUtil.java
@@ -1,7 +1,12 @@
 package com.wanderersoftherift.wotr.util;
 
+import net.minecraft.core.BlockPos;
 import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.Containers;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.phys.Vec3;
+import net.neoforged.neoforge.items.IItemHandler;
 import net.neoforged.neoforge.items.ItemStackHandler;
 
 /**
@@ -19,7 +24,7 @@ public final class ItemStackHandlerUtil {
      * @param player
      * @param handler
      */
-    public static void placeInPlayerInventoryOrDrop(ServerPlayer player, ItemStackHandler handler) {
+    public static void placeInPlayerInventoryOrDrop(ServerPlayer player, IItemHandler handler) {
         for (int i = 0; i < handler.getSlots(); i++) {
             // TODO: may need extra logic to handle oversized stacks
             placeInPlayerInventoryOrDrop(player, handler.getStackInSlot(i).copy());
@@ -51,7 +56,7 @@ public final class ItemStackHandlerUtil {
      * @param handler
      * @param player
      */
-    public static void addOrGiveToPlayerOrDrop(ItemStack item, ItemStackHandler handler, ServerPlayer player) {
+    public static void addOrGiveToPlayerOrDrop(ItemStack item, IItemHandler handler, ServerPlayer player) {
         ItemStack residual = item;
         for (int i = 0; i < handler.getSlots(); i++) {
             if (handler.getStackInSlot(i).isEmpty()) {
@@ -66,6 +71,35 @@ public final class ItemStackHandlerUtil {
                 player.drop(item, false);
             } else {
                 player.getInventory().placeItemBackInInventory(item);
+            }
+        }
+    }
+
+    /**
+     * Drops the contents of the IItemHandler
+     * 
+     * @param level       The level to drop the contents into
+     * @param pos         The position to drop the contents
+     * @param itemHandler The handler to empty
+     */
+    public static void dropContents(Level level, BlockPos pos, IItemHandler itemHandler) {
+        dropContents(level, pos.getCenter(), itemHandler);
+    }
+
+    /**
+     * Drops the contents of the IItemHandler
+     *
+     * @param level       The level to drop the contents into
+     * @param pos         The position to drop the contents
+     * @param itemHandler The handler to empty
+     */
+    public static void dropContents(Level level, Vec3 pos, IItemHandler itemHandler) {
+        for (int slot = 0; slot < itemHandler.getSlots(); slot++) {
+            int amount = itemHandler.getStackInSlot(slot).getCount();
+            while (amount > 0) {
+                ItemStack stack = itemHandler.extractItem(slot, amount, false);
+                Containers.dropItemStack(level, pos.x, pos.y, pos.z, stack);
+                amount = itemHandler.getStackInSlot(slot).getCount();
             }
         }
     }


### PR DESCRIPTION
Closes #498 

Updates AbilityBench to drop contents on destroy, and creates utility methods for dropping the contents of `IItemHandler`s.