### PR TITLE
Experimental dungeon layout for rifts

### DIFF
--- a/src/main/java/com/wanderersoftherift/wotr/core/rift/parameter/definitions/ConstantRiftParameter.java
+++ b/src/main/java/com/wanderersoftherift/wotr/core/rift/parameter/definitions/ConstantRiftParameter.java
@@ -6,7 +6,7 @@ import net.minecraft.util.RandomSource;
 
 import java.util.function.Function;
 
-public record ConstantRiftParameter(double value) implements RiftParameter {
+public record ConstantRiftParameter(double value) implements RiftParameterDefinition {
     public static final Codec<ConstantRiftParameter> CODEC = Codec.DOUBLE.xmap(ConstantRiftParameter::new,
             ConstantRiftParameter::value);
 

--- a/src/main/java/com/wanderersoftherift/wotr/core/rift/parameter/definitions/PolynomialRiftParameter.java
+++ b/src/main/java/com/wanderersoftherift/wotr/core/rift/parameter/definitions/PolynomialRiftParameter.java
@@ -8,11 +8,13 @@ import net.minecraft.util.RandomSource;
 import java.util.List;
 import java.util.function.Function;
 
-public record PolynomialRiftParameter(List<RiftParameter> orderParameters, RiftParameter position)
+public record PolynomialRiftParameter(List<RiftParameterDefinition> orderParameters, RiftParameterDefinition position)
         implements RegisteredRiftParameter {
     public static final MapCodec<PolynomialRiftParameter> CODEC = RecordCodecBuilder.mapCodec(instance -> instance
-            .group(RiftParameter.CODEC.listOf().fieldOf("orders").forGetter(PolynomialRiftParameter::orderParameters),
-                    RiftParameter.CODEC.optionalFieldOf("position", TierRiftParameter.INSTANCE)
+            .group(RiftParameterDefinition.CODEC.listOf()
+                    .fieldOf("orders")
+                    .forGetter(PolynomialRiftParameter::orderParameters),
+                    RiftParameterDefinition.CODEC.optionalFieldOf("position", TierRiftParameter.INSTANCE)
                             .forGetter(PolynomialRiftParameter::position))
             .apply(instance, PolynomialRiftParameter::new));
 

--- a/src/main/java/com/wanderersoftherift/wotr/core/rift/parameter/definitions/PowRiftParameter.java
+++ b/src/main/java/com/wanderersoftherift/wotr/core/rift/parameter/definitions/PowRiftParameter.java
@@ -7,10 +7,12 @@ import net.minecraft.util.RandomSource;
 
 import java.util.function.Function;
 
-public record PowRiftParameter(RiftParameter base, RiftParameter exp) implements RegisteredRiftParameter {
+public record PowRiftParameter(RiftParameterDefinition base, RiftParameterDefinition exp)
+        implements RegisteredRiftParameter {
     public static final MapCodec<PowRiftParameter> CODEC = RecordCodecBuilder.mapCodec(instance -> instance.group(
-            RiftParameter.CODEC.optionalFieldOf("base", TierRiftParameter.INSTANCE).forGetter(PowRiftParameter::base),
-            RiftParameter.CODEC.optionalFieldOf("exponent", TierRiftParameter.INSTANCE)
+            RiftParameterDefinition.CODEC.optionalFieldOf("base", TierRiftParameter.INSTANCE)
+                    .forGetter(PowRiftParameter::base),
+            RiftParameterDefinition.CODEC.optionalFieldOf("exponent", TierRiftParameter.INSTANCE)
                     .forGetter(PowRiftParameter::exp))
             .apply(instance, PowRiftParameter::new));
 

--- a/src/main/java/com/wanderersoftherift/wotr/core/rift/parameter/definitions/RandomRangeRiftParameter.java
+++ b/src/main/java/com/wanderersoftherift/wotr/core/rift/parameter/definitions/RandomRangeRiftParameter.java
@@ -7,12 +7,13 @@ import net.minecraft.util.RandomSource;
 
 import java.util.function.Function;
 
-public record RandomRangeRiftParameter(RiftParameter min, RiftParameter max) implements RegisteredRiftParameter {
+public record RandomRangeRiftParameter(RiftParameterDefinition min, RiftParameterDefinition max)
+        implements RegisteredRiftParameter {
     public static final MapCodec<RandomRangeRiftParameter> CODEC = RecordCodecBuilder
             .mapCodec(instance -> instance.group(
-                    RiftParameter.CODEC.optionalFieldOf("min", TierRiftParameter.INSTANCE)
+                    RiftParameterDefinition.CODEC.optionalFieldOf("min", TierRiftParameter.INSTANCE)
                             .forGetter(RandomRangeRiftParameter::min),
-                    RiftParameter.CODEC.optionalFieldOf("max", TierRiftParameter.INSTANCE)
+                    RiftParameterDefinition.CODEC.optionalFieldOf("max", TierRiftParameter.INSTANCE)
                             .forGetter(RandomRangeRiftParameter::max))
                     .apply(instance, RandomRangeRiftParameter::new));
 

--- a/src/main/java/com/wanderersoftherift/wotr/core/rift/parameter/definitions/ReferenceRiftParameter.java
+++ b/src/main/java/com/wanderersoftherift/wotr/core/rift/parameter/definitions/ReferenceRiftParameter.java
@@ -7,7 +7,7 @@ import net.minecraft.util.RandomSource;
 
 import java.util.function.Function;
 
-public record ReferenceRiftParameter(Holder<RiftParameter> value) implements RiftParameter {
+public record ReferenceRiftParameter(Holder<RiftParameter> value) implements RiftParameterDefinition {
     public static final Codec<ReferenceRiftParameter> CODEC = RiftParameter.HOLDER_CODEC
             .xmap(ReferenceRiftParameter::new, ReferenceRiftParameter::value);
 

--- a/src/main/java/com/wanderersoftherift/wotr/core/rift/parameter/definitions/RegisteredRiftParameter.java
+++ b/src/main/java/com/wanderersoftherift/wotr/core/rift/parameter/definitions/RegisteredRiftParameter.java
@@ -6,7 +6,7 @@ import com.wanderersoftherift.wotr.init.WotrRegistries;
 
 import java.util.function.Function;
 
-public interface RegisteredRiftParameter extends RiftParameter {
+public interface RegisteredRiftParameter extends RiftParameterDefinition {
     Codec<RegisteredRiftParameter> CODEC = WotrRegistries.RIFT_PARAMETER_TYPES.byNameCodec()
             .dispatch(RegisteredRiftParameter::getCodec, Function.identity());
 

--- a/src/main/java/com/wanderersoftherift/wotr/core/rift/parameter/definitions/RiftParameter.java
+++ b/src/main/java/com/wanderersoftherift/wotr/core/rift/parameter/definitions/RiftParameter.java
@@ -1,7 +1,7 @@
 package com.wanderersoftherift.wotr.core.rift.parameter.definitions;
 
-import com.mojang.datafixers.util.Either;
 import com.mojang.serialization.Codec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
 import com.wanderersoftherift.wotr.init.WotrRegistries;
 import com.wanderersoftherift.wotr.serialization.LaxRegistryCodec;
 import net.minecraft.core.Holder;
@@ -10,21 +10,15 @@ import net.minecraft.util.RandomSource;
 
 import java.util.function.Function;
 
-public interface RiftParameter {
-    Codec<Holder<RiftParameter>> HOLDER_CODEC = LaxRegistryCodec.ref(WotrRegistries.Keys.RIFT_PARAMETER_CONFIGS);
-    Codec<RiftParameter> CODEC = Codec
-            .either(Codec.either(ConstantRiftParameter.CODEC, ReferenceRiftParameter.CODEC),
-                    RegisteredRiftParameter.CODEC)
-            .xmap(it -> it.map(it2 -> it2.map(it3 -> it3, it3 -> it3), it2 -> it2), it -> switch (it) {
-                case ConstantRiftParameter constantRiftParameterType ->
-                    Either.left(Either.left(constantRiftParameterType));
-                case RegisteredRiftParameter registeredRiftParameterType -> Either.right(registeredRiftParameterType);
-                case ReferenceRiftParameter referenceRiftParameterType ->
-                    Either.left(Either.right(referenceRiftParameterType));
-                default -> throw new IllegalStateException("Unexpected value: " + it);
-            });
+public record RiftParameter(RiftParameterDefinition defaultValue) implements RiftParameterDefinition {
 
-    Codec<RiftParameter> DEFINITION_CODEC = CODEC.fieldOf("initializer").codec();
+    public static final Codec<Holder<RiftParameter>> HOLDER_CODEC = LaxRegistryCodec
+            .ref(WotrRegistries.Keys.RIFT_PARAMETER_CONFIGS);
+    public static final Codec<RiftParameter> CODEC = RecordCodecBuilder.create(instance -> instance.group(
+            RiftParameterDefinition.CODEC.fieldOf("initializer").forGetter(RiftParameter::defaultValue)
+    ).apply(instance, RiftParameter::new));
 
-    double getValue(int tier, RandomSource rng, Function<ResourceKey<RiftParameter>, Double> parameterGetter);
+    public double getValue(int tier, RandomSource rng, Function<ResourceKey<RiftParameter>, Double> parameterGetter) {
+        return defaultValue.getValue(tier, rng, parameterGetter);
+    }
 }

--- a/src/main/java/com/wanderersoftherift/wotr/core/rift/parameter/definitions/RiftParameterDefinition.java
+++ b/src/main/java/com/wanderersoftherift/wotr/core/rift/parameter/definitions/RiftParameterDefinition.java
@@ -1,0 +1,27 @@
+package com.wanderersoftherift.wotr.core.rift.parameter.definitions;
+
+import com.mojang.datafixers.util.Either;
+import com.mojang.serialization.Codec;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.util.RandomSource;
+
+import java.util.function.Function;
+
+/**
+ * Interface for elements that compose a rift parameter definition - either in part or in whole
+ */
+public interface RiftParameterDefinition {
+    Codec<RiftParameterDefinition> CODEC = Codec
+            .either(Codec.either(ConstantRiftParameter.CODEC, ReferenceRiftParameter.CODEC),
+                    RegisteredRiftParameter.CODEC)
+            .xmap(it -> it.map(it2 -> it2.map(it3 -> it3, it3 -> it3), it2 -> it2), it -> switch (it) {
+                case ConstantRiftParameter constantRiftParameterType ->
+                    Either.left(Either.left(constantRiftParameterType));
+                case RegisteredRiftParameter registeredRiftParameterType -> Either.right(registeredRiftParameterType);
+                case ReferenceRiftParameter referenceRiftParameterType ->
+                    Either.left(Either.right(referenceRiftParameterType));
+                default -> throw new IllegalStateException("Unexpected value: " + it);
+            });
+
+    double getValue(int tier, RandomSource rng, Function<ResourceKey<RiftParameter>, Double> parameterGetter);
+}

--- a/src/main/java/com/wanderersoftherift/wotr/datagen/WotrLanguageProvider.java
+++ b/src/main/java/com/wanderersoftherift/wotr/datagen/WotrLanguageProvider.java
@@ -130,6 +130,9 @@ public class WotrLanguageProvider extends LanguageProvider {
         addTheme("processor", "Processor");
         addTheme("swamp", "Swamp");
 
+        add(WanderersOfTheRift.translationId("rift_generator_preset", "default"), "Default");
+        add(WanderersOfTheRift.translationId("rift_generator_preset", "dungeon"), "Dungeon");
+
         WotrBlocks.BLOCK_FAMILY_HELPERS.forEach(helper -> {
             // addBlock(helper.getBlock(), getTranslationString(helper.getBlock().get()));
             helper.getVariants().forEach((variant, block) -> addBlock(block, getTranslationString(block.get())));

--- a/src/main/java/com/wanderersoftherift/wotr/datagen/WotrRecipeProvider.java
+++ b/src/main/java/com/wanderersoftherift/wotr/datagen/WotrRecipeProvider.java
@@ -21,6 +21,7 @@ import net.minecraft.tags.ItemTags;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
+import net.minecraft.world.item.crafting.Ingredient;
 import net.minecraft.world.level.block.Blocks;
 import net.neoforged.neoforge.registries.DeferredHolder;
 import org.jetbrains.annotations.NotNull;
@@ -293,6 +294,21 @@ public class WotrRecipeProvider extends RecipeProvider {
                 .save(output, WanderersOfTheRift.id("rift_objective_stealth"));
         // </editor-fold>
 
+        // <editor-fold desc="WotR Key Forge Generator">
+        // Add recipes for the mod's generators
+        KeyForgeRecipe
+                .create(WotrDataComponentType.RiftKeyData.GENERATOR_PRESET.get(),
+                        DeferredHolder.create(WotrRegistries.Keys.GENERATOR_PRESETS, WanderersOfTheRift.id("default")))
+                .setPriority(-1)
+                .save(output, WanderersOfTheRift.id("rift_generator_default"));
+        KeyForgeRecipe
+                .create(WotrDataComponentType.RiftKeyData.GENERATOR_PRESET.get(),
+                        DeferredHolder.create(WotrRegistries.Keys.GENERATOR_PRESETS, WanderersOfTheRift.id("dungeon")))
+                .setPriority(1)
+                .withItemReq(Ingredient.of(Items.COMPASS))
+                .save(output, WanderersOfTheRift.id("rift_generator_dungeon"));
+
+        // </editor-fold>
     }
 
     // The runner to add to the data generator

--- a/src/main/java/com/wanderersoftherift/wotr/init/WotrRegistries.java
+++ b/src/main/java/com/wanderersoftherift/wotr/init/WotrRegistries.java
@@ -309,8 +309,7 @@ public class WotrRegistries {
         event.dataPackRegistry(Keys.MODIFIER_EFFECTS, ModifierEffect.DIRECT_CODEC, ModifierEffect.DIRECT_CODEC);
         event.dataPackRegistry(Keys.MODIFIERS, Modifier.DIRECT_CODEC, Modifier.DIRECT_CODEC);
         event.dataPackRegistry(Keys.RIFT_THEMES, RiftTheme.DIRECT_CODEC, RiftTheme.DIRECT_SYNC_CODEC);
-        event.dataPackRegistry(Keys.RIFT_PARAMETER_CONFIGS, RiftParameter.DEFINITION_CODEC,
-                RiftParameter.DEFINITION_CODEC);
+        event.dataPackRegistry(Keys.RIFT_PARAMETER_CONFIGS, RiftParameter.CODEC, RiftParameter.CODEC);
         event.dataPackRegistry(Keys.RUNEGEM_DATA, RunegemData.CODEC, RunegemData.CODEC);
         event.dataPackRegistry(Keys.GEAR_IMPLICITS_CONFIG, ImplicitConfig.CODEC, ImplicitConfig.CODEC);
         event.dataPackRegistry(Keys.ABILITY_UPGRADES, AbilityUpgrade.CODEC, AbilityUpgrade.CODEC);

--- a/src/main/java/com/wanderersoftherift/wotr/init/worldgen/WotrRiftLayouts.java
+++ b/src/main/java/com/wanderersoftherift/wotr/init/worldgen/WotrRiftLayouts.java
@@ -4,6 +4,7 @@ import com.mojang.serialization.MapCodec;
 import com.wanderersoftherift.wotr.WanderersOfTheRift;
 import com.wanderersoftherift.wotr.init.WotrRegistries;
 import com.wanderersoftherift.wotr.world.level.levelgen.layout.DefaultLayoutFactory;
+import com.wanderersoftherift.wotr.world.level.levelgen.layout.DungeonLayout;
 import com.wanderersoftherift.wotr.world.level.levelgen.layout.LayeredFiniteRiftLayout;
 import com.wanderersoftherift.wotr.world.level.levelgen.layout.LayeredInfiniteRiftLayout;
 import com.wanderersoftherift.wotr.world.level.levelgen.layout.RiftLayout;
@@ -21,5 +22,7 @@ public class WotrRiftLayouts {
             .register("infinite_layered_layout", () -> LayeredInfiniteRiftLayout.Factory.CODEC);
     public static final Supplier<MapCodec<DefaultLayoutFactory>> DEFAULT_LAYOUT = LAYOUTS.register("default_layout",
             () -> DefaultLayoutFactory.CODEC);
+    public static final Supplier<MapCodec<DungeonLayout.Factory>> DUNGEON_LAYOUT = LAYOUTS.register("dungeon",
+            () -> DungeonLayout.Factory.CODEC);
 
 }

--- a/src/main/java/com/wanderersoftherift/wotr/item/riftkey/RiftKey.java
+++ b/src/main/java/com/wanderersoftherift/wotr/item/riftkey/RiftKey.java
@@ -95,7 +95,7 @@ public class RiftKey extends Item {
         if (stack.has(WotrDataComponentType.RiftKeyData.GENERATOR_PRESET)) {
             var preset = stack.get(WotrDataComponentType.RiftKeyData.GENERATOR_PRESET);
             var presetString = preset.unwrapKey()
-                    .map(it -> Component.literal(it.location().toString()).withStyle())
+                    .map(it -> Component.translatable(it.location().toLanguageKey("rift_generator_preset")).withStyle())
                     .orElse(Component.literal("Custom")
                             .withStyle(Style.EMPTY.withColor(ChatFormatting.GRAY).withItalic(true)));
             components.add(Component

--- a/src/main/java/com/wanderersoftherift/wotr/world/level/levelgen/layout/DungeonLayout.java
+++ b/src/main/java/com/wanderersoftherift/wotr/world/level/levelgen/layout/DungeonLayout.java
@@ -62,10 +62,13 @@ public class DungeonLayout implements RiftLayout {
     private final RoomRandomizer portalRoomRandomizer;
     private final RoomRandomizer mainRoomRandomizer;
     private final RoomRandomizer connectingRoomRandomizer;
+    private final RiftShape shape;
 
-    public DungeonLayout(long seed, RoomRandomizer portalRoomRandomizer, RoomRandomizer mainRoomRandomizer,
-            RoomRandomizer connectingRoomRandomizer, int maxDepth, float branchRate, int mainRoomInterval) {
+    public DungeonLayout(long seed, RiftShape shape, RoomRandomizer portalRoomRandomizer,
+            RoomRandomizer mainRoomRandomizer, RoomRandomizer connectingRoomRandomizer, int maxDepth, float branchRate,
+            int mainRoomInterval) {
         this.seed = seed;
+        this.shape = shape;
         this.portalRoomRandomizer = portalRoomRandomizer;
         this.mainRoomRandomizer = mainRoomRandomizer;
         this.connectingRoomRandomizer = connectingRoomRandomizer;
@@ -176,8 +179,9 @@ public class DungeonLayout implements RiftLayout {
      * @return Whether the chunk sections occupied by the room are currently empty
      */
     private boolean canPlace(RoomRiftSpace room) {
+
         for (Vec3i loc : room.sections()) {
-            if (spaces.containsKey(loc)) {
+            if (!shape.isPositionValid(loc.getX(), loc.getY(), loc.getZ()) || spaces.containsKey(loc)) {
                 return false;
             }
         }
@@ -226,8 +230,8 @@ public class DungeonLayout implements RiftLayout {
                             .getParameter(MAIN_ROOM_INTERVAL_PARAM)
                             .get());
 
-            return new DungeonLayout(this.seed.orElse(riftConfig.seed()), portalRandomizer, mainRandomizer,
-                    connectorRandomizer, maxDepth, branchRate, mainRoomInterval);
+            return new DungeonLayout(this.seed.orElse(riftConfig.seed()), riftShape(riftConfig), portalRandomizer,
+                    mainRandomizer, connectorRandomizer, maxDepth, branchRate, mainRoomInterval);
         }
 
         @Override

--- a/src/main/java/com/wanderersoftherift/wotr/world/level/levelgen/layout/DungeonLayout.java
+++ b/src/main/java/com/wanderersoftherift/wotr/world/level/levelgen/layout/DungeonLayout.java
@@ -1,0 +1,216 @@
+package com.wanderersoftherift.wotr.world.level.levelgen.layout;
+
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.MapCodec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import com.wanderersoftherift.wotr.WanderersOfTheRift;
+import com.wanderersoftherift.wotr.core.rift.RiftConfig;
+import com.wanderersoftherift.wotr.core.rift.parameter.definitions.RiftParameter;
+import com.wanderersoftherift.wotr.init.WotrRegistries;
+import com.wanderersoftherift.wotr.init.worldgen.WotrRiftConfigDataTypes;
+import com.wanderersoftherift.wotr.world.level.FastRiftGenerator;
+import com.wanderersoftherift.wotr.world.level.levelgen.layout.shape.RiftShape;
+import com.wanderersoftherift.wotr.world.level.levelgen.layout.shape.UnlimitedRiftShape;
+import com.wanderersoftherift.wotr.world.level.levelgen.processor.util.ProcessorUtil;
+import com.wanderersoftherift.wotr.world.level.levelgen.space.RiftSpace;
+import com.wanderersoftherift.wotr.world.level.levelgen.space.RoomRiftSpace;
+import com.wanderersoftherift.wotr.world.level.levelgen.space.VoidRiftSpace;
+import com.wanderersoftherift.wotr.world.level.levelgen.template.randomizers.RoomRandomizer;
+import com.wanderersoftherift.wotr.world.level.levelgen.template.randomizers.RoomRandomizerImpl;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.core.RegistryAccess;
+import net.minecraft.core.Vec3i;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.util.RandomSource;
+import net.minecraft.util.Unit;
+
+import java.lang.ref.WeakReference;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicReference;
+
+public class DungeonLayout implements RiftLayout {
+    private static final ResourceKey<RiftParameter> BRANCH_RATE_PARAM = ResourceKey
+            .create(WotrRegistries.Keys.RIFT_PARAMETER_CONFIGS, WanderersOfTheRift.id("dungeon_rift/branch_rate"));
+    private static final ResourceKey<RiftParameter> MAIN_ROOM_INTERVAL_PARAM = ResourceKey.create(
+            WotrRegistries.Keys.RIFT_PARAMETER_CONFIGS, WanderersOfTheRift.id("dungeon_rift/main_room_interval"));
+    private static final ResourceKey<RiftParameter> MAX_DEPTH_PARAM = ResourceKey
+            .create(WotrRegistries.Keys.RIFT_PARAMETER_CONFIGS, WanderersOfTheRift.id("dungeon_rift/max_depth"));
+
+    private final long seed;
+    private final int maxDepth;
+    private final float branchRate;
+    private final int mainRoomInterval;
+    private final Map<Vec3i, RiftSpace> spaces = new LinkedHashMap<>();
+    private final AtomicReference<WeakReference<Thread>> generatorThread = new AtomicReference<>(null);
+    private final CompletableFuture<Unit> generationCompletion = new CompletableFuture<>();
+    private final RoomRandomizer portalRoomRandomizer;
+    private final RoomRandomizer mainRoomRandomizer;
+    private final RoomRandomizer connectingRoomRandomizer;
+
+    public DungeonLayout(long seed, RoomRandomizer portalRoomRandomizer, RoomRandomizer mainRoomRandomizer,
+            RoomRandomizer connectingRoomRandomizer, int maxDepth, float branchRate, int mainRoomInterval) {
+        this.seed = seed;
+        this.portalRoomRandomizer = portalRoomRandomizer;
+        this.mainRoomRandomizer = mainRoomRandomizer;
+        this.connectingRoomRandomizer = connectingRoomRandomizer;
+        this.maxDepth = maxDepth;
+        this.branchRate = branchRate;
+        this.mainRoomInterval = mainRoomInterval;
+    }
+
+    @Override
+    public RiftSpace getChunkSpace(int x, int y, int z) {
+        var rand = ProcessorUtil.createRandom(
+                ProcessorUtil.getRandomSeed(new BlockPos(0, 0, 0), seed));
+        tryGenerate(rand);
+        return getSpaceAt(x, y, z);
+    }
+
+    private RiftSpace getSpaceAt(int x, int y, int z) {
+        return spaces.getOrDefault(new Vec3i(x, y, z), VoidRiftSpace.INSTANCE);
+    }
+
+    private void tryGenerate(RandomSource random) {
+        if (generatorThread.get() == null && random != null
+                && generatorThread.compareAndSet(null, new WeakReference<>(Thread.currentThread()))) {
+            generate(random);
+        }
+        try {
+            generationCompletion.get();
+        } catch (ExecutionException | InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void generate(RandomSource random) {
+        RoomRiftSpace originRoom = portalRoomRandomizer.randomSpace(random, new Vec3i(3, 3, 3)).offset(-1, -1, -1);
+        originRoom.forEachSection((pos) -> spaces.put(pos, originRoom));
+
+        Deque<Branch> openBranches = new ArrayDeque<>();
+        openBranches.add((new Branch(originRoom, 4, 0)));
+
+        int mainBranches = (int) Math.floor(branchRate);
+        float additionalBranchChance = branchRate % 1;
+
+        while (!openBranches.isEmpty()) {
+            Branch branch = openBranches.pop();
+            RoomRandomizer randomizer;
+
+            boolean mainRoom = branch.depth % mainRoomInterval == 0;
+            if (mainRoom) {
+                randomizer = mainRoomRandomizer;
+            } else {
+                randomizer = connectingRoomRandomizer;
+            }
+            for (int i = 0; i < branch.count; i++) {
+                RoomRiftSpace unpositionedRoom = randomizer.randomSpace(random, new Vec3i(3, 3, 3));
+                List<RoomRiftSpace> possibleRoomPlacements = branch.origin.corridors()
+                        .stream()
+                        .filter(corridor -> !spaces.containsKey(corridor.getConnectingPos(branch.origin)))
+                        .flatMap(outCorridor -> {
+                            Direction connectingDir = outCorridor.direction().getOpposite();
+                            Vec3i connectingPos = outCorridor.getConnectingPos(branch.origin);
+                            return unpositionedRoom.corridors()
+                                    .stream()
+                                    .filter(inCorridor -> inCorridor.direction() == connectingDir)
+                                    .map(inCorridor -> unpositionedRoom
+                                            .offset(connectingPos.subtract(inCorridor.position())));
+                        })
+                        .filter(this::canPlace)
+                        .toList();
+                if (possibleRoomPlacements.isEmpty()) {
+                    // No way to connect room
+                    WanderersOfTheRift.LOGGER.info("Unable to find possible room location");
+                    continue;
+                }
+                RoomRiftSpace newRoom = possibleRoomPlacements.get(random.nextInt(possibleRoomPlacements.size()));
+                newRoom.forEachSection(pos -> spaces.put(pos, newRoom));
+                if (branch.depth >= maxDepth - 1) {
+                    continue;
+                }
+
+                int newBranches;
+                if (mainRoom) {
+                    newBranches = mainBranches + ((random.nextFloat() < additionalBranchChance) ? 1 : 0);
+                } else {
+                    newBranches = 1;
+                }
+
+                openBranches.add(new Branch(newRoom, newBranches, branch.depth + 1));
+            }
+        }
+
+        generationCompletion.complete(Unit.INSTANCE);
+    }
+
+    private boolean canPlace(RoomRiftSpace room) {
+        for (Vec3i loc : room.sections()) {
+            if (spaces.containsKey(loc)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private record Branch(RoomRiftSpace origin, int count, int depth) {
+    }
+
+    public record Factory(Optional<Long> seed) implements RiftLayout.Factory {
+
+        public static final MapCodec<Factory> CODEC = RecordCodecBuilder.mapCodec(it -> it.group(
+                Codec.LONG.optionalFieldOf("seed").forGetter(Factory::seed)
+        ).apply(it, Factory::new));
+
+        @Override
+        public MapCodec<? extends RiftLayout.Factory> codec() {
+            return CODEC;
+        }
+
+        @Override
+        public RiftLayout createLayout(MinecraftServer server, RiftConfig riftConfig) {
+
+            RegistryAccess registryAccess = server.registryAccess();
+            RoomRandomizer portalRandomizer = new RoomRandomizerImpl.Factory(
+                    registryAccess.holderOrThrow(
+                            ResourceKey.create(Registries.TEMPLATE_POOL, WanderersOfTheRift.id("rift/room_portal"))),
+                    RoomRandomizerImpl.SINGLE_SIZE_SPACE_HOLDER_FACTORY).createRandomizer(server);
+            RoomRandomizer mainRandomizer = new RoomRandomizerImpl.Factory(
+                    registryAccess.holderOrThrow(
+                            ResourceKey.create(Registries.TEMPLATE_POOL, WanderersOfTheRift.id("rift/dungeon/main"))),
+                    RoomRandomizerImpl.SINGLE_SIZE_SPACE_HOLDER_FACTORY).createRandomizer(server);
+            RoomRandomizer connectorRandomizer = new RoomRandomizerImpl.Factory(
+                    registryAccess.holderOrThrow(ResourceKey.create(Registries.TEMPLATE_POOL,
+                            WanderersOfTheRift.id("rift/dungeon/connector"))),
+                    RoomRandomizerImpl.SINGLE_SIZE_SPACE_HOLDER_FACTORY).createRandomizer(server);
+
+            int maxDepth = (int) Math.round(riftConfig.getCustomData(WotrRiftConfigDataTypes.INITIAL_RIFT_PARAMETERS)
+                    .getParameter(MAX_DEPTH_PARAM)
+                    .get());
+            float branchRate = (float) riftConfig.getCustomData(WotrRiftConfigDataTypes.INITIAL_RIFT_PARAMETERS)
+                    .getParameter(BRANCH_RATE_PARAM)
+                    .get();
+            int mainRoomInterval = (int) Math
+                    .round(riftConfig.getCustomData(WotrRiftConfigDataTypes.INITIAL_RIFT_PARAMETERS)
+                            .getParameter(MAIN_ROOM_INTERVAL_PARAM)
+                            .get());
+
+            return new DungeonLayout(this.seed.orElse(riftConfig.seed()), portalRandomizer, mainRandomizer,
+                    connectorRandomizer, maxDepth, branchRate, mainRoomInterval);
+        }
+
+        @Override
+        public RiftShape riftShape(RiftConfig config) {
+            return new UnlimitedRiftShape(24 - FastRiftGenerator.MARGIN_LAYERS);
+        }
+    }
+}

--- a/src/main/java/com/wanderersoftherift/wotr/world/level/levelgen/space/RiftSpace.java
+++ b/src/main/java/com/wanderersoftherift/wotr/world/level/levelgen/space/RiftSpace.java
@@ -6,7 +6,9 @@ import com.wanderersoftherift.wotr.world.level.levelgen.template.RiftGeneratable
 import net.minecraft.core.Vec3i;
 
 import javax.annotation.Nullable;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Consumer;
 
 /**
  * This describes volume allocated for room to generate in
@@ -24,4 +26,26 @@ public interface RiftSpace {
     TripleMirror templateTransform();
 
     @Nullable RiftGeneratable template();
+
+    default void forEachSection(Consumer<Vec3i> consumer) {
+        for (int z = 0; z < size().getZ(); z++) {
+            for (int y = 0; y < size().getY(); y++) {
+                for (int x = 0; x < size().getX(); x++) {
+                    consumer.accept(origin().offset(x, y, z));
+                }
+            }
+        }
+    }
+
+    default List<Vec3i> sections() {
+        List<Vec3i> result = new ArrayList<>();
+        for (int z = 0; z < size().getZ(); z++) {
+            for (int y = 0; y < size().getY(); y++) {
+                for (int x = 0; x < size().getX(); x++) {
+                    result.add(origin().offset(x, y, z));
+                }
+            }
+        }
+        return result;
+    }
 }

--- a/src/main/java/com/wanderersoftherift/wotr/world/level/levelgen/space/RiftSpace.java
+++ b/src/main/java/com/wanderersoftherift/wotr/world/level/levelgen/space/RiftSpace.java
@@ -11,14 +11,18 @@ import java.util.List;
 import java.util.function.Consumer;
 
 /**
- * This describes volume allocated for room to generate in
- *
- * size units are in chunks
+ * This describes volume allocated for room to generate in size units are in chunk sections
  */
 public interface RiftSpace {
 
+    /**
+     * @return Origin (lower corner) in chunk sections
+     */
     Vec3i origin();
 
+    /**
+     * @return Size in chunk sections
+     */
     Vec3i size();
 
     List<RiftSpaceCorridor> corridors();
@@ -27,6 +31,11 @@ public interface RiftSpace {
 
     @Nullable RiftGeneratable template();
 
+    /**
+     * Applies the provided consumer to all sections composing the space
+     * 
+     * @param consumer
+     */
     default void forEachSection(Consumer<Vec3i> consumer) {
         for (int z = 0; z < size().getZ(); z++) {
             for (int y = 0; y < size().getY(); y++) {
@@ -37,15 +46,12 @@ public interface RiftSpace {
         }
     }
 
+    /**
+     * @return A list of all sections composing the space
+     */
     default List<Vec3i> sections() {
         List<Vec3i> result = new ArrayList<>();
-        for (int z = 0; z < size().getZ(); z++) {
-            for (int y = 0; y < size().getY(); y++) {
-                for (int x = 0; x < size().getX(); x++) {
-                    result.add(origin().offset(x, y, z));
-                }
-            }
-        }
+        forEachSection(result::add);
         return result;
     }
 }

--- a/src/main/java/com/wanderersoftherift/wotr/world/level/levelgen/space/RoomRiftSpace.java
+++ b/src/main/java/com/wanderersoftherift/wotr/world/level/levelgen/space/RoomRiftSpace.java
@@ -15,6 +15,10 @@ public record RoomRiftSpace(Vec3i size, Vec3i center, List<RiftSpaceCorridor> co
         return center.offset(-size.getX() / 2, -size.getY() / 2, -size.getZ() / 2);
     }
 
+    public RoomRiftSpace offset(Vec3i pos) {
+        return offset(pos.getX(), pos.getY(), pos.getZ());
+    }
+
     public RoomRiftSpace offset(int x, int y, int z) {
         return new RoomRiftSpace(size, center.offset(x, y, z), corridors, template, templateTransform);
     }

--- a/src/main/resources/data/wotr/worldgen/template_pool/rift/dungeon/connector.json
+++ b/src/main/resources/data/wotr/worldgen/template_pool/rift/dungeon/connector.json
@@ -1,0 +1,293 @@
+{
+  "fallback": "wotr:rift/room_terminator",
+  "elements": [
+    {
+      "weight": 36,
+      "element": {
+        "location": "wotr:rift/room/chaos/221/twist-1-wout",
+        "processors": "wotr:room_theme_default",
+        "projection": "rigid",
+        "element_type": "minecraft:single_pool_element"
+      }
+    },
+    {
+      "weight": 36,
+      "element": {
+        "location": "wotr:rift/room/chaos/212/fountain-1-pat",
+        "processors": "wotr:room_theme_default",
+        "projection": "rigid",
+        "element_type": "minecraft:single_pool_element"
+      }
+    },
+    {
+      "weight": 12,
+      "element": {
+        "location": "wotr:rift/room/chaos/111/tavern-1-warren",
+        "processors": "wotr:room_theme_default",
+        "projection": "rigid",
+        "element_type": "minecraft:single_pool_element"
+      }
+    },
+    {
+      "weight": 12,
+      "element": {
+        "location": "wotr:rift/room/chaos/111/filler-1-pat",
+        "processors": "wotr:room_theme_default",
+        "projection": "rigid",
+        "element_type": "minecraft:single_pool_element"
+      }
+    },
+    {
+      "weight": 44,
+      "element": {
+        "location": "wotr:rift/room/chaos/131/spiraling_snake-1-warren",
+        "processors": "wotr:room_theme_default",
+        "projection": "rigid",
+        "element_type": "minecraft:single_pool_element"
+      }
+    },
+    {
+      "weight": 68,
+      "element": {
+        "location": "wotr:rift/room/chaos/232/stalactite-1-pat-grimm",
+        "processors": "wotr:room_theme_default",
+        "projection": "rigid",
+        "element_type": "minecraft:single_pool_element"
+      }
+    },
+    {
+      "weight": 44,
+      "element": {
+        "location": "wotr:rift/room/chaos/311/twisting_hallway-1-warren",
+        "processors": "wotr:room_theme_default",
+        "projection": "rigid",
+        "element_type": "minecraft:single_pool_element"
+      }
+    },
+    {
+      "weight": 76,
+      "element": {
+        "location": "wotr:rift/room/chaos/331/girder_and_barrel-1-warren",
+        "processors": "wotr:room_theme_default",
+        "projection": "rigid",
+        "element_type": "minecraft:single_pool_element"
+      }
+    },
+    {
+      "weight": 56,
+      "element": {
+        "location": "wotr:rift/room/chaos/321/fallingfoor-1-rachaelrose",
+        "processors": "wotr:room_theme_default",
+        "projection": "rigid",
+        "element_type": "minecraft:single_pool_element"
+      }
+    },
+    {
+      "weight": 68,
+      "element": {
+        "location": "wotr:rift/room/chaos/322/tree-1-ada",
+        "processors": "wotr:room_12_to_wood",
+        "projection": "rigid",
+        "element_type": "minecraft:single_pool_element"
+      }
+    },
+    {
+      "weight": 48,
+      "element": {
+        "location": "wotr:rift/room/chaos/222/main_jump-1-rachaelrose",
+        "processors": "wotr:room_theme_default",
+        "projection": "rigid",
+        "element_type": "minecraft:single_pool_element"
+      }
+    },
+    {
+      "weight": 56,
+      "element": {
+        "location": "wotr:rift/room/chaos/231/staircase-1-ada",
+        "processors": "wotr:room_12_to_wood",
+        "projection": "rigid",
+        "element_type": "minecraft:single_pool_element"
+      }
+    },
+    {
+      "weight": 56,
+      "element": {
+        "location": "wotr:rift/room/chaos/231/caveychaos-1-jyu",
+        "processors": "wotr:room_theme_default",
+        "projection": "rigid",
+        "element_type": "minecraft:single_pool_element"
+      }
+    },
+    {
+      "weight": 24,
+      "element": {
+        "location": "wotr:rift/room/chaos/211/lava_path-1-rev",
+        "processors": "wotr:room_theme_default",
+        "projection": "rigid",
+        "element_type": "minecraft:single_pool_element"
+      }
+    },
+    {
+      "weight": 12,
+      "element": {
+        "location": "wotr:rift/room/chaos/111/lavapassage-1-jj",
+        "processors": "wotr:room_theme_default",
+        "projection": "rigid",
+        "element_type": "minecraft:single_pool_element"
+      }
+    },
+    {
+      "weight": 24,
+      "element": {
+        "location": "wotr:rift/room/chaos/121/stair_spiral-1-grimm",
+        "processors": "wotr:room_theme_default",
+        "projection": "rigid",
+        "element_type": "minecraft:single_pool_element"
+      }
+    },
+    {
+      "weight": 36,
+      "element": {
+        "location": "wotr:rift/room/chaos/212/bakery-1-rsh",
+        "processors": "wotr:room_theme_default",
+        "projection": "rigid",
+        "element_type": "minecraft:single_pool_element"
+      }
+    },
+    {
+      "weight": 56,
+      "element": {
+        "location": "wotr:rift/room/chaos/312/water_cave-1-rachaelrose",
+        "processors": "wotr:room_theme_default",
+        "projection": "rigid",
+        "element_type": "minecraft:single_pool_element"
+      }
+    },
+    {
+      "weight": 88,
+      "element": {
+        "location": "wotr:rift/room/chaos/332/city_stair-3-mal",
+        "processors": "wotr:room_multiple_ruins_and_wood",
+        "projection": "rigid",
+        "element_type": "minecraft:single_pool_element"
+      }
+    },
+    {
+      "weight": 24,
+      "element": {
+        "location": "wotr:rift/room/chaos/211/two_caves-1-jyu",
+        "processors": "wotr:room_theme_default",
+        "projection": "rigid",
+        "element_type": "minecraft:single_pool_element"
+      }
+    },
+    {
+      "weight": 24,
+      "element": {
+        "location": "wotr:rift/room/chaos/211/sneaky_caves-1-mal",
+        "processors": "wotr:room_theme_default",
+        "projection": "rigid",
+        "element_type": "minecraft:single_pool_element"
+      }
+    },
+    {
+      "weight": 48,
+      "element": {
+        "location": "wotr:rift/room/chaos/222/fish-1-rachaelrose",
+        "processors": "wotr:room_theme_default",
+        "projection": "rigid",
+        "element_type": "minecraft:single_pool_element"
+      }
+    },
+    {
+      "weight": 44,
+      "element": {
+        "location": "wotr:rift/room/chaos/311/void_cracks-1-rachaelrose",
+        "processors": "wotr:room_theme_default",
+        "projection": "rigid",
+        "element_type": "minecraft:single_pool_element"
+      }
+    },
+    {
+      "weight": 56,
+      "element": {
+        "location": "wotr:rift/room/chaos/321/plumbers_nightmare-1-wh4i3",
+        "processors": "wotr:room_theme_default",
+        "projection": "rigid",
+        "element_type": "minecraft:single_pool_element"
+      }
+    },
+    {
+      "weight": 12,
+      "element": {
+        "location": "wotr:rift/room/chaos/111/upside_down_passage-1-wh4i3",
+        "processors": "wotr:room_theme_default",
+        "projection": "rigid",
+        "element_type": "minecraft:single_pool_element"
+      }
+    },
+    {
+      "weight": 24,
+      "element": {
+        "location": "wotr:rift/room/chaos/121/tears-1-rachaelrose",
+        "processors": "wotr:room_theme_default",
+        "projection": "rigid",
+        "element_type": "minecraft:single_pool_element"
+      }
+    },
+    {
+      "weight": 48,
+      "element": {
+        "location": "wotr:rift/room/chaos/222/thingy-1-kiara",
+        "processors": "wotr:room_theme_default",
+        "projection": "rigid",
+        "element_type": "minecraft:single_pool_element"
+      }
+    },
+    {
+      "weight": 36,
+      "element": {
+        "location": "wotr:rift/room/chaos/221/twolayercave-1-jyu",
+        "processors": "wotr:room_theme_default",
+        "projection": "rigid",
+        "element_type": "minecraft:single_pool_element"
+      }
+    },
+    {
+      "weight": 12,
+      "element": {
+        "location": "wotr:rift/room/chaos/111/greebles-1-jyu",
+        "processors": "wotr:room_theme_default",
+        "projection": "rigid",
+        "element_type": "minecraft:single_pool_element"
+      }
+    },
+    {
+      "weight": 48,
+      "element": {
+        "location": "wotr:rift/room/chaos/222/chicken-2-rachaelrose",
+        "processors": "wotr:room_theme_default",
+        "projection": "rigid",
+        "element_type": "minecraft:single_pool_element"
+      }
+    },
+    {
+      "weight": 56,
+      "element": {
+        "location": "wotr:rift/room/chaos/312/brickhall-1-jyu",
+        "processors": "wotr:room_theme_default",
+        "projection": "rigid",
+        "element_type": "minecraft:single_pool_element"
+      }
+    },
+    {
+      "weight": 24,
+      "element": {
+        "location": "wotr:rift/room/chaos/121/tallhallway-1-jyu",
+        "processors": "wotr:room_theme_default",
+        "projection": "rigid",
+        "element_type": "minecraft:single_pool_element"
+      }
+    }
+  ]
+}

--- a/src/main/resources/data/wotr/worldgen/template_pool/rift/dungeon/main.json
+++ b/src/main/resources/data/wotr/worldgen/template_pool/rift/dungeon/main.json
@@ -1,0 +1,329 @@
+{
+  "fallback": "wotr:rift/room_terminator",
+  "elements": [
+    {
+      "weight": 100,
+      "element": {
+        "location": "wotr:rift/room/stable/333/cave_pillar-1-wout",
+        "processors": "wotr:room_theme_default",
+        "projection": "rigid",
+        "element_type": "minecraft:single_pool_element"
+      }
+    },
+    {
+      "weight": 100,
+      "element": {
+        "location": "wotr:rift/room/stable/333/lakey_cave-1-jyu",
+        "processors": "wotr:room_theme_default",
+        "projection": "rigid",
+        "element_type": "minecraft:single_pool_element"
+      }
+    },
+    {
+      "weight": 100,
+      "element": {
+        "location": "wotr:rift/room/stable/333/waterfall_cave-1-jyu",
+        "processors": "wotr:room_theme_default",
+        "projection": "rigid",
+        "element_type": "minecraft:single_pool_element"
+      }
+    },
+    {
+      "weight": 100,
+      "element": {
+        "location": "wotr:rift/room/stable/333/open_cave-1-jyu",
+        "processors": "wotr:room_theme_default",
+        "projection": "rigid",
+        "element_type": "minecraft:single_pool_element"
+      }
+    },
+    {
+      "weight": 100,
+      "element": {
+        "location": "wotr:rift/room/stable/333/cavey_cave-1-jyu",
+        "processors": "wotr:room_theme_default",
+        "projection": "rigid",
+        "element_type": "minecraft:single_pool_element"
+      }
+    },
+    {
+      "weight": 100,
+      "element": {
+        "location": "wotr:rift/room/stable/333/caves-1-grimm",
+        "processors": "wotr:room_theme_default",
+        "projection": "rigid",
+        "element_type": "minecraft:single_pool_element"
+      }
+    },
+    {
+      "weight": 100,
+      "element": {
+        "location": "wotr:rift/room/stable/333/caves-2-grimm",
+        "processors": "wotr:room_theme_default",
+        "projection": "rigid",
+        "element_type": "minecraft:single_pool_element"
+      }
+    },
+    {
+      "weight": 100,
+      "element": {
+        "location": "wotr:rift/room/stable/333/caves-3-grimm",
+        "processors": "wotr:room_theme_default",
+        "projection": "rigid",
+        "element_type": "minecraft:single_pool_element"
+      }
+    },
+    {
+      "weight": 100,
+      "element": {
+        "location": "wotr:rift/room/stable/333/caves-4-grimm",
+        "processors": "wotr:room_theme_default",
+        "projection": "rigid",
+        "element_type": "minecraft:single_pool_element"
+      }
+    },
+    {
+      "weight": 100,
+      "element": {
+        "location": "wotr:rift/room/stable/333/caves-5-grimm",
+        "processors": "wotr:room_theme_default",
+        "projection": "rigid",
+        "element_type": "minecraft:single_pool_element"
+      }
+    },
+    {
+      "weight": 100,
+      "element": {
+        "location": "wotr:rift/room/stable/333/cave_mine-1-jj",
+        "processors": "wotr:room_theme_default",
+        "projection": "rigid",
+        "element_type": "minecraft:single_pool_element"
+      }
+    },
+    {
+      "weight": 100,
+      "element": {
+        "location": "wotr:rift/room/stable/333/tree-1-kammy",
+        "processors": "wotr:room_12_to_wood",
+        "projection": "rigid",
+        "element_type": "minecraft:single_pool_element"
+      }
+    },
+    {
+      "weight": 100,
+      "element": {
+        "location": "wotr:rift/room/stable/333/waterfall-1-kammy",
+        "processors": "wotr:room_theme_default",
+        "projection": "rigid",
+        "element_type": "minecraft:single_pool_element"
+      }
+    },
+    {
+      "weight": 100,
+      "element": {
+        "location": "wotr:rift/room/stable/333/cave-1-kammy",
+        "processors": "wotr:room_theme_default",
+        "projection": "rigid",
+        "element_type": "minecraft:single_pool_element"
+      }
+    },
+    {
+      "weight": 100,
+      "element": {
+        "location": "wotr:rift/room/stable/333/open_cave-1-kammy",
+        "processors": "wotr:room_theme_default",
+        "projection": "rigid",
+        "element_type": "minecraft:single_pool_element"
+      }
+    },
+    {
+      "weight": 100,
+      "element": {
+        "location": "wotr:rift/room/stable/333/waterfall_cave-1-kammy",
+        "processors": "wotr:room_theme_default",
+        "projection": "rigid",
+        "element_type": "minecraft:single_pool_element"
+      }
+    },
+    {
+      "weight": 100,
+      "element": {
+        "location": "wotr:rift/room/stable/333/forst-1-rachael",
+        "processors": "wotr:room_12_to_wood",
+        "projection": "rigid",
+        "element_type": "minecraft:single_pool_element"
+      }
+    },
+    {
+      "weight": 100,
+      "element": {
+        "location": "wotr:rift/room/stable/333/false_idols-1-wh4i3_kiara",
+        "processors": "wotr:room_theme_default",
+        "projection": "rigid",
+        "element_type": "minecraft:single_pool_element"
+      }
+    },
+    {
+      "weight": 100,
+      "element": {
+        "location": "wotr:rift/room/stable/333/openopencave-1-jyu",
+        "processors": "wotr:room_theme_default",
+        "projection": "rigid",
+        "element_type": "minecraft:single_pool_element"
+      }
+    },
+    {
+      "weight": 100,
+      "element": {
+        "location": "wotr:rift/room/unstable/323/ruins-1-wout",
+        "processors": "wotr:room_multiple_ruins",
+        "projection": "rigid",
+        "element_type": "minecraft:single_pool_element"
+      }
+    },
+    {
+      "weight": 100,
+      "element": {
+        "location": "wotr:rift/room/unstable/333/winding_flower_tree-1-mal",
+        "processors": "wotr:room_12_to_wood",
+        "projection": "rigid",
+        "element_type": "minecraft:single_pool_element"
+      }
+    },
+    {
+      "weight": 100,
+      "element": {
+        "location": "wotr:rift/room/unstable/313/turning_trails-1-warren",
+        "processors": "wotr:room_theme_default",
+        "projection": "rigid",
+        "element_type": "minecraft:single_pool_element"
+      }
+    },
+    {
+      "weight": 100,
+      "element": {
+        "location": "wotr:rift/room/unstable/323/hub_hub_bub-4-mal",
+        "processors": "wotr:room_theme_default",
+        "projection": "rigid",
+        "element_type": "minecraft:single_pool_element"
+      }
+    },
+    {
+      "weight": 100,
+      "element": {
+        "location": "wotr:rift/room/unstable/333/ruined_bridge-1-wh4i3",
+        "processors": "wotr:room_theme_default",
+        "projection": "rigid",
+        "element_type": "minecraft:single_pool_element"
+      }
+    },
+    {
+      "weight": 100,
+      "element": {
+        "location": "wotr:rift/room/unstable/323/tallcave-1-jyu",
+        "processors": "wotr:room_theme_default",
+        "projection": "rigid",
+        "element_type": "minecraft:single_pool_element"
+      }
+    },
+    {
+      "weight": 100,
+      "element": {
+        "location": "wotr:rift/room/unstable/313/flatcave-1-jyu",
+        "processors": "wotr:room_theme_default",
+        "projection": "rigid",
+        "element_type": "minecraft:single_pool_element"
+      }
+    },
+    {
+      "weight": 100,
+      "element": {
+        "location": "wotr:rift/room/unstable/323/village-1-rachaelrose",
+        "processors": "wotr:room_theme_default",
+        "projection": "rigid",
+        "element_type": "minecraft:single_pool_element"
+      }
+    },
+    {
+      "weight": 100,
+      "element": {
+        "location": "wotr:rift/room/unstable/323/village-2-rachaelrose",
+        "processors": "wotr:room_theme_default",
+        "projection": "rigid",
+        "element_type": "minecraft:single_pool_element"
+      }
+    },
+    {
+      "weight": 100,
+      "element": {
+        "location": "wotr:rift/room/unstable/323/village-3-rachaelrose",
+        "processors": "wotr:room_12_to_wood",
+        "projection": "rigid",
+        "element_type": "minecraft:single_pool_element"
+      }
+    },
+    {
+      "weight": 100,
+      "element": {
+        "location": "wotr:rift/room/unstable/333/hall-1-jyu",
+        "processors": "wotr:room_theme_default",
+        "projection": "rigid",
+        "element_type": "minecraft:single_pool_element"
+      }
+    },
+    {
+      "weight": 88,
+      "element": {
+        "location": "wotr:rift/room/chaos/323/stablechaoscave-1-jyu",
+        "processors": "wotr:room_theme_default",
+        "projection": "rigid",
+        "element_type": "minecraft:single_pool_element"
+      }
+    },
+    {
+      "weight": 76,
+      "element": {
+        "location": "wotr:rift/room/chaos/313/twocaves-2-jyu",
+        "processors": "wotr:room_theme_default",
+        "projection": "rigid",
+        "element_type": "minecraft:single_pool_element"
+      }
+    },
+    {
+      "weight": 108,
+      "element": {
+        "location": "wotr:rift/room/chaos/333/menger_sponge-1-wh4i3",
+        "processors": "wotr:room_theme_default",
+        "projection": "rigid",
+        "element_type": "minecraft:single_pool_element"
+      }
+    },
+    {
+      "weight": 88,
+      "element": {
+        "location": "wotr:rift/room/chaos/323/overlapping_hallways-1-warren",
+        "processors": "wotr:room_theme_default",
+        "projection": "rigid",
+        "element_type": "minecraft:single_pool_element"
+      }
+    },
+    {
+      "weight": 76,
+      "element": {
+        "location": "wotr:rift/room/chaos/313/thin_cave-1-rachaelrose",
+        "processors": "wotr:room_theme_default",
+        "projection": "rigid",
+        "element_type": "minecraft:single_pool_element"
+      }
+    },
+    {
+      "weight": 108,
+      "element": {
+        "location": "wotr:rift/room/chaos/333/winding_path-1-mal",
+        "processors": "wotr:room_theme_default",
+        "projection": "rigid",
+        "element_type": "minecraft:single_pool_element"
+      }
+    }
+  ]
+}

--- a/src/main/resources/data/wotr/wotr/rift_parameter/dungeon_rift/branch_rate.json
+++ b/src/main/resources/data/wotr/wotr/rift_parameter/dungeon_rift/branch_rate.json
@@ -1,0 +1,3 @@
+{
+    "initializer": 1.5
+}

--- a/src/main/resources/data/wotr/wotr/rift_parameter/dungeon_rift/main_room_interval.json
+++ b/src/main/resources/data/wotr/wotr/rift_parameter/dungeon_rift/main_room_interval.json
@@ -1,0 +1,3 @@
+{
+    "initializer": 3
+}

--- a/src/main/resources/data/wotr/wotr/rift_parameter/dungeon_rift/max_depth.json
+++ b/src/main/resources/data/wotr/wotr/rift_parameter/dungeon_rift/max_depth.json
@@ -1,0 +1,5 @@
+{
+    "initializer": {
+        "type": "wotr:tier"
+    }
+}

--- a/src/main/resources/data/wotr/wotr/worldgen/rift_generator_preset/dungeon.json
+++ b/src/main/resources/data/wotr/wotr/worldgen/rift_generator_preset/dungeon.json
@@ -1,0 +1,72 @@
+{
+    "layout": {
+        "type": "wotr:dungeon"
+    },
+    "room_generator": {
+        "type": "wotr:cached",
+        "base": {
+            "type": "wotr:layer_generatable",
+            "layered_generatable": {
+                "type": "wotr:perimeter",
+                "perimeter_block": "minecraft:bedrock"
+            },
+            "base": {
+                "type": "wotr:core"
+            }
+        }
+    },
+    "post_processing_steps": [
+        {
+            "type": "wotr:corridor_blender",
+            "validator": {
+                "type": "wotr:or",
+                "values": [
+                    {
+                        "type": "wotr:by_generator_layout"
+                    },
+                    {
+                        "type": "wotr:opposite",
+                        "base": {
+                            "type": "wotr:by_generator_layout"
+                        }
+                    }
+                ]
+            }
+        }
+    ],
+    "jigsaw_processors": [
+        {
+            "type": "wotr:filter_remove",
+            "namespace": "wotr",
+            "path_pattern": "rift/ring_"
+        },
+        {
+            "type": "wotr:shuffle"
+        },
+        {
+            "type": "wotr:replace_bulk",
+            "values": {
+                "wotr:rift/poi/free/3": {
+                    "new_pool": "wotr:rift/anomaly/free/3",
+                    "chance": 0.15
+                },
+                "wotr:rift/poi/ceiling/3": {
+                    "new_pool": "wotr:rift/anomaly/ceiling/3",
+                    "chance": 0.15
+                },
+                "wotr:rift/poi/halfway/3": {
+                    "new_pool": "wotr:rift/anomaly/halfway/3",
+                    "chance": 0.15
+                },
+                "wotr:rift/poi/inwall/3": {
+                    "new_pool": "wotr:rift/anomaly/inwall/3",
+                    "chance": 0.15
+                }
+            }
+        }
+    ],
+    "empty_chunk_generatable": {
+        "type": "wotr:single_block_chunk",
+        "block": "minecraft:bedrock"
+    }
+}


### PR DESCRIPTION
### Overview

Introduces an experimental dungeon layout for rifts. Places rooms as branches, with major rooms separated by connecting rooms. By default there is a major room every 3 rooms along the branches, and at a major room there is a 50% chance of a second branch.

### Usage

To test, modify a key with the command: `/wotr riftKey generator setPreset wotr:dungeon`. The size of the rift is currently determine by tier, with no limit although 16 seems to be plenty. At some size performance will tank/memory will be exhausted, but this is true for large finite rift layouts too.

The generation can be further finetuned with:
* `/wotr riftKey parameter wotr:dungeon_rift/branch_rate <value>` - how many branches from each main room, with fractional parts being the chance for an additional branch. Defaults to `1.5`
* `/wotr riftKey parameter wotr:dungeon_rift/main_room_interval <value>` how frequently main rooms (3x_x3) appear. Main rooms appear immediately after the portal room, and then every nth room as determined by this value. Defaults to `3`.
* `/wotr riftKey parameter wotr:dungeon_rift/max_depth <value>` how many rooms out from the portal room the branches will generate. Defaults to the tier of the rift.

### Future Work

There is undoubtedly a lot that can be done to expand or improve this approach. For example, adding terminator rooms, improving the room pools, better randomisation of branching, optimisation of generation. The logic behind selecting an placing a room is fairly basic - more could be done here though it will add complexity and cost. Gameplay-wise having objectives inserting only into main rooms may be interesting. Having exit portals or teleporters between terminating rooms may also help prevent backtracking if that is an issue too.