### PR TITLE
fix: #449

### DIFF
--- a/src/main/java/com/wanderersoftherift/wotr/gui/menu/RuneAnvilMenu.java
+++ b/src/main/java/com/wanderersoftherift/wotr/gui/menu/RuneAnvilMenu.java
@@ -199,6 +199,8 @@ public class RuneAnvilMenu extends AbstractContainerMenu {
                 if (i >= this.activeSocketSlots) {
                     slot.set(ItemStack.EMPTY);
                     slot.setSocket(null);
+                    slot.setLockedSocket(null);
+                    slot.setShape(null);
                     continue;
                 }
 


### PR DESCRIPTION
Rune anvil now correctly updates socket slot display

closes #449 