### PR TITLE
Feat: Cuboid Targeting Area

### DIFF
--- a/src/main/java/com/wanderersoftherift/wotr/abilities/targeting/shape/CuboidShape.java
+++ b/src/main/java/com/wanderersoftherift/wotr/abilities/targeting/shape/CuboidShape.java
@@ -1,0 +1,70 @@
+package com.wanderersoftherift.wotr.abilities.targeting.shape;
+
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.MapCodec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import com.wanderersoftherift.wotr.abilities.AbilityContext;
+import com.wanderersoftherift.wotr.init.WotrAttributes;
+import com.wanderersoftherift.wotr.modifier.effect.AttributeModifierEffect;
+import com.wanderersoftherift.wotr.modifier.effect.ModifierEffect;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.phys.AABB;
+import net.minecraft.world.phys.Vec3;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.function.Predicate;
+
+public record CuboidShape(Vec3 area, boolean alignToBlock) implements TargetAreaShape {
+
+    public static final MapCodec<CuboidShape> CODEC = RecordCodecBuilder.mapCodec(instance -> instance.group(
+            Vec3.CODEC.fieldOf("area").forGetter(CuboidShape::area),
+            Codec.BOOL.optionalFieldOf("align_to_block", false).forGetter(CuboidShape::alignToBlock)
+    ).apply(instance, CuboidShape::new));
+
+    @Override
+    public MapCodec<? extends TargetAreaShape> codec() {
+        return CODEC;
+    }
+
+    @Override
+    public AABB getAABB(Vec3 location, Vec3 direction, @Nullable AbilityContext context) {
+        Vec3 size = getArea(context);
+        Vec3 center = location;
+
+        if (alignToBlock) {
+            center = BlockPos.containing(center).getCenter();
+        }
+
+        boolean flip = Math.abs(direction.x) > Math.abs(direction.z);
+        AABB result = AABB.ofSize(
+                center, flip ? size.z : size.x, size.y, flip ? size.x : size.z
+        );
+        return result;
+
+    }
+
+    @Override
+    public Predicate<Entity> getEntityPredicate(Vec3 location, Vec3 direction, @Nullable AbilityContext context) {
+        return entity -> true;
+    }
+
+    @Override
+    public Predicate<BlockPos> getBlockPredicate(Vec3 location, Vec3 direction, @Nullable AbilityContext context) {
+        return pos -> true;
+    }
+
+    @Override
+    public boolean isRelevant(ModifierEffect modifierEffect) {
+        return modifierEffect instanceof AttributeModifierEffect attributeModifierEffect
+                && WotrAttributes.ABILITY_AOE.equals(attributeModifierEffect.attribute());
+    }
+
+    private Vec3 getArea(@Nullable AbilityContext context) {
+        if (context == null) {
+            return area;
+        }
+        float modifier = context.getAbilityAttribute(WotrAttributes.ABILITY_AOE, (float) area.length());
+        return area.scale(modifier / area.length());
+    }
+}

--- a/src/main/java/com/wanderersoftherift/wotr/init/ability/WotrTargetAreaShapes.java
+++ b/src/main/java/com/wanderersoftherift/wotr/init/ability/WotrTargetAreaShapes.java
@@ -3,6 +3,7 @@ package com.wanderersoftherift.wotr.init.ability;
 import com.mojang.serialization.MapCodec;
 import com.wanderersoftherift.wotr.WanderersOfTheRift;
 import com.wanderersoftherift.wotr.abilities.targeting.shape.CubeShape;
+import com.wanderersoftherift.wotr.abilities.targeting.shape.CuboidShape;
 import com.wanderersoftherift.wotr.abilities.targeting.shape.SphereShape;
 import com.wanderersoftherift.wotr.abilities.targeting.shape.TargetAreaShape;
 import com.wanderersoftherift.wotr.init.WotrRegistries;
@@ -17,6 +18,8 @@ public final class WotrTargetAreaShapes {
 
     public static final Supplier<MapCodec<? extends TargetAreaShape>> CUBE = SHAPES.register("cube",
             () -> CubeShape.CODEC);
+    public static final Supplier<MapCodec<? extends TargetAreaShape>> CUBOID = SHAPES.register("cuboid",
+            () -> CuboidShape.CODEC);
     public static final Supplier<MapCodec<? extends TargetAreaShape>> SPHERE = SHAPES.register("sphere",
             () -> SphereShape.CODEC);
 }


### PR DESCRIPTION
Adds a cuboid shape to area targeting.
Adds UseOriginDirection boolean to keep the direction of source prior to Area Targeting, such that walls can be created depending on facing of player, rather than the direction of first target hit.

Closes #503 