### PR TITLE
Instant loot framework

### DIFF
--- a/src/main/java/com/wanderersoftherift/wotr/WanderersOfTheRift.java
+++ b/src/main/java/com/wanderersoftherift/wotr/WanderersOfTheRift.java
@@ -22,6 +22,7 @@ import com.wanderersoftherift.wotr.init.WotrEntityDataSerializers;
 import com.wanderersoftherift.wotr.init.WotrEntitySubPredicates;
 import com.wanderersoftherift.wotr.init.WotrEquipmentSlotTypes;
 import com.wanderersoftherift.wotr.init.WotrFluids;
+import com.wanderersoftherift.wotr.init.WotrInstantLootTypes;
 import com.wanderersoftherift.wotr.init.WotrItems;
 import com.wanderersoftherift.wotr.init.WotrMenuTypes;
 import com.wanderersoftherift.wotr.init.WotrMobEffects;
@@ -162,6 +163,8 @@ public class WanderersOfTheRift {
         WotrTrackedAbilityTriggers.TRIGGERS.register(modEventBus);
 
         WotrMobInteractions.MOB_INTERACTIONS.register(modEventBus);
+
+        WotrInstantLootTypes.INSTANT_LOOT_TYPES.register(modEventBus);
 
         // Gear
         WotrModifierSourceTypes.MODIFIER_SOURCE.register(modEventBus);

--- a/src/main/java/com/wanderersoftherift/wotr/core/quest/reward/AbilityResourceReward.java
+++ b/src/main/java/com/wanderersoftherift/wotr/core/quest/reward/AbilityResourceReward.java
@@ -1,0 +1,35 @@
+package com.wanderersoftherift.wotr.core.quest.reward;
+
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import com.wanderersoftherift.wotr.abilities.AbilityResource;
+import com.wanderersoftherift.wotr.core.quest.Reward;
+import com.wanderersoftherift.wotr.init.WotrAttachments;
+import com.wanderersoftherift.wotr.serialization.DualCodec;
+import net.minecraft.core.Holder;
+import net.minecraft.network.codec.ByteBufCodecs;
+import net.minecraft.network.codec.StreamCodec;
+import net.minecraft.world.entity.player.Player;
+
+public record AbilityResourceReward(float amount, Holder<AbilityResource> abilityResource) implements Reward {
+    public static final DualCodec<AbilityResourceReward> TYPE = new DualCodec<>(
+            RecordCodecBuilder.mapCodec(instance -> instance
+                    .group(Codec.FLOAT.fieldOf("amount").forGetter(AbilityResourceReward::amount),
+                            AbilityResource.HOLDER_CODEC.fieldOf("resource")
+                                    .forGetter(AbilityResourceReward::abilityResource))
+                    .apply(instance, AbilityResourceReward::new)),
+            StreamCodec.composite(ByteBufCodecs.FLOAT, AbilityResourceReward::amount,
+                    ByteBufCodecs.fromCodecWithRegistries(AbilityResource.HOLDER_CODEC),
+                    AbilityResourceReward::abilityResource, AbilityResourceReward::new));
+
+    @Override
+    public DualCodec<? extends Reward> getType() {
+        return TYPE;
+    }
+
+    @Override
+    public void apply(Player player) {
+        var abilityResourceData = player.getData(WotrAttachments.ABILITY_RESOURCE_DATA);
+        abilityResourceData.useAmount(abilityResource, -amount);
+    }
+}

--- a/src/main/java/com/wanderersoftherift/wotr/core/quest/reward/HealReward.java
+++ b/src/main/java/com/wanderersoftherift/wotr/core/quest/reward/HealReward.java
@@ -1,0 +1,24 @@
+package com.wanderersoftherift.wotr.core.quest.reward;
+
+import com.mojang.serialization.Codec;
+import com.wanderersoftherift.wotr.core.quest.Reward;
+import com.wanderersoftherift.wotr.serialization.DualCodec;
+import net.minecraft.network.codec.ByteBufCodecs;
+import net.minecraft.world.entity.player.Player;
+
+public record HealReward(float amount) implements Reward {
+    public static final DualCodec<HealReward> TYPE = new DualCodec<>(
+            Codec.FLOAT.fieldOf("amount").xmap(HealReward::new, HealReward::amount),
+            ByteBufCodecs.FLOAT.map(HealReward::new, HealReward::amount)
+    );
+
+    @Override
+    public DualCodec<? extends Reward> getType() {
+        return TYPE;
+    }
+
+    @Override
+    public void apply(Player player) {
+        player.heal(amount);
+    }
+}

--- a/src/main/java/com/wanderersoftherift/wotr/datagen/WotrChestLootTableProvider.java
+++ b/src/main/java/com/wanderersoftherift/wotr/datagen/WotrChestLootTableProvider.java
@@ -2,11 +2,14 @@ package com.wanderersoftherift.wotr.datagen;
 
 import com.wanderersoftherift.wotr.WanderersOfTheRift;
 import com.wanderersoftherift.wotr.abilities.Ability;
+import com.wanderersoftherift.wotr.core.quest.reward.HealReward;
+import com.wanderersoftherift.wotr.core.quest.reward.provider.FixedRewardProvider;
 import com.wanderersoftherift.wotr.init.WotrItems;
 import com.wanderersoftherift.wotr.init.WotrRegistries;
 import com.wanderersoftherift.wotr.init.WotrTags;
 import com.wanderersoftherift.wotr.loot.functions.AbilityHolderFunction;
 import com.wanderersoftherift.wotr.loot.functions.GearSocketsFunction;
+import com.wanderersoftherift.wotr.loot.functions.RewardInstantLootFunction;
 import com.wanderersoftherift.wotr.loot.functions.RollGearFunction;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.core.registries.Registries;
@@ -60,7 +63,9 @@ public record WotrChestLootTableProvider(HolderLookup.Provider registries) imple
                                 .add(LootItem.lootTableItem(Items.POTION)
                                         .when(riftTier().max(1))
                                         .setWeight(10)
-                                        .apply(SetPotionFunction.setPotion(Potions.HEALING)))
+                                        .apply(SetPotionFunction.setPotion(Potions.HEALING))
+                                        .apply(RewardInstantLootFunction
+                                                .builder(() -> new FixedRewardProvider<>(new HealReward(6)))))
                                 .add(LootItem.lootTableItem(Items.BREAD)
                                         .setWeight(20)
                                         .apply(SetItemCountFunction.setCount(UniformGenerator.between(1.0F, 2.0F))))

--- a/src/main/java/com/wanderersoftherift/wotr/gui/menu/RiftCompleteMenu.java
+++ b/src/main/java/com/wanderersoftherift/wotr/gui/menu/RiftCompleteMenu.java
@@ -127,8 +127,7 @@ public class RiftCompleteMenu extends AbstractRewardMenu {
     public void removed(@NotNull Player player) {
         super.removed(player);
         this.access.execute((world, pos) -> {
-            ServerPlayer serverPlayer = (ServerPlayer) player;
-            ItemStackHandlerUtil.placeInPlayerInventoryOrDrop(serverPlayer, itemRewards);
+            ItemStackHandlerUtil.placeInPlayerInventoryOrDrop(player, itemRewards);
         });
     }
 

--- a/src/main/java/com/wanderersoftherift/wotr/gui/menu/quest/QuestCompletionMenu.java
+++ b/src/main/java/com/wanderersoftherift/wotr/gui/menu/quest/QuestCompletionMenu.java
@@ -154,8 +154,6 @@ public class QuestCompletionMenu extends AbstractContainerMenu {
     @Override
     public void removed(@NotNull Player player) {
         super.removed(player);
-        if (player instanceof ServerPlayer serverPlayer) {
-            ItemStackHandlerUtil.placeInPlayerInventoryOrDrop(serverPlayer, handInItems);
-        }
+        ItemStackHandlerUtil.placeInPlayerInventoryOrDrop(player, handInItems);
     }
 }

--- a/src/main/java/com/wanderersoftherift/wotr/gui/menu/reward/RewardMenu.java
+++ b/src/main/java/com/wanderersoftherift/wotr/gui/menu/reward/RewardMenu.java
@@ -8,7 +8,6 @@ import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.codec.ByteBufCodecs;
 import net.minecraft.network.codec.StreamCodec;
-import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.SimpleMenuProvider;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.entity.player.Player;
@@ -101,8 +100,7 @@ public class RewardMenu extends AbstractRewardMenu {
     public void removed(@NotNull Player player) {
         super.removed(player);
         this.access.execute((world, pos) -> {
-            ServerPlayer serverPlayer = (ServerPlayer) player;
-            ItemStackHandlerUtil.placeInPlayerInventoryOrDrop(serverPlayer, itemRewards);
+            ItemStackHandlerUtil.placeInPlayerInventoryOrDrop(player, itemRewards);
         });
     }
 }

--- a/src/main/java/com/wanderersoftherift/wotr/init/WotrDataComponentType.java
+++ b/src/main/java/com/wanderersoftherift/wotr/init/WotrDataComponentType.java
@@ -16,6 +16,7 @@ import com.wanderersoftherift.wotr.item.implicit.GearImplicits;
 import com.wanderersoftherift.wotr.item.riftkey.RiftKeyParameterData;
 import com.wanderersoftherift.wotr.item.runegem.RunegemData;
 import com.wanderersoftherift.wotr.item.socket.GearSockets;
+import com.wanderersoftherift.wotr.loot.InstantLoot;
 import com.wanderersoftherift.wotr.util.listedit.ListEdit;
 import com.wanderersoftherift.wotr.world.level.levelgen.RiftPostProcessingStep;
 import com.wanderersoftherift.wotr.world.level.levelgen.jigsaw.JigsawListProcessor;
@@ -68,6 +69,9 @@ public class WotrDataComponentType {
 
     public static final DeferredHolder<DataComponentType<?>, DataComponentType<Integer>> GEAR_RIFT_TIER = register(
             "gear_rift_tier", Codec.INT, ByteBufCodecs.INT);
+
+    public static final DeferredHolder<DataComponentType<?>, DataComponentType<InstantLoot>> INSTANT_LOOT = register(
+            "instant_loot", InstantLoot.CODEC, ByteBufCodecs.fromCodecWithRegistries(InstantLoot.CODEC));
 
     public static final class AbilityContextData {
         public static final DeferredHolder<DataComponentType<?>, DataComponentType<ChainAbilityState>> CHAIN_ABILITY_STATE = register(

--- a/src/main/java/com/wanderersoftherift/wotr/init/WotrInstantLootTypes.java
+++ b/src/main/java/com/wanderersoftherift/wotr/init/WotrInstantLootTypes.java
@@ -1,0 +1,16 @@
+package com.wanderersoftherift.wotr.init;
+
+import com.mojang.serialization.MapCodec;
+import com.wanderersoftherift.wotr.WanderersOfTheRift;
+import com.wanderersoftherift.wotr.loot.InstantLoot;
+import com.wanderersoftherift.wotr.loot.RewardInstantLoot;
+import net.neoforged.neoforge.registries.DeferredHolder;
+import net.neoforged.neoforge.registries.DeferredRegister;
+
+public class WotrInstantLootTypes {
+    public static final DeferredRegister<MapCodec<? extends InstantLoot>> INSTANT_LOOT_TYPES = DeferredRegister
+            .create(WotrRegistries.INSTANT_LOOT_TYPES, WanderersOfTheRift.MODID);
+
+    public static final DeferredHolder<MapCodec<? extends InstantLoot>, MapCodec<RewardInstantLoot>> REWARD_INSTANT_LOOT = INSTANT_LOOT_TYPES
+            .register("reward", () -> RewardInstantLoot.CODEC);
+}

--- a/src/main/java/com/wanderersoftherift/wotr/init/WotrRegistries.java
+++ b/src/main/java/com/wanderersoftherift/wotr/init/WotrRegistries.java
@@ -36,6 +36,7 @@ import com.wanderersoftherift.wotr.entity.player.progression.ProgressionTrack;
 import com.wanderersoftherift.wotr.gui.menu.character.CharacterMenuItem;
 import com.wanderersoftherift.wotr.item.implicit.ImplicitConfig;
 import com.wanderersoftherift.wotr.item.runegem.RunegemData;
+import com.wanderersoftherift.wotr.loot.InstantLoot;
 import com.wanderersoftherift.wotr.modifier.Modifier;
 import com.wanderersoftherift.wotr.modifier.effect.ModifierEffect;
 import com.wanderersoftherift.wotr.modifier.source.ModifierSource;
@@ -138,6 +139,8 @@ public class WotrRegistries {
             Keys.ANOMALY_TASK_TYPE).sync(true).create();
     public static final Registry<MapCodec<? extends SpawnFunction>> SPAWN_FUNCTION_TYPES = new RegistryBuilder<>(
             Keys.SPAWN_FUNCTION_TYPES).sync(true).create();
+    public static final Registry<MapCodec<? extends InstantLoot>> INSTANT_LOOT_TYPES = new RegistryBuilder<>(
+            Keys.INSTANT_LOOT_TYPES).sync(true).create();
 
     public static final class Keys {
 
@@ -185,6 +188,9 @@ public class WotrRegistries {
                 .createRegistryKey(WanderersOfTheRift.id("npc"));
         public static final ResourceKey<Registry<CharacterMenuItem>> CHARACTER_MENU_ITEMS = ResourceKey
                 .createRegistryKey(WanderersOfTheRift.id("character_menu_item"));
+
+        public static final ResourceKey<Registry<MapCodec<? extends InstantLoot>>> INSTANT_LOOT_TYPES = ResourceKey
+                .createRegistryKey(WanderersOfTheRift.id("instant_loot_type"));
 
         // Abilities
         public static final ResourceKey<Registry<Ability>> ABILITIES = ResourceKey
@@ -293,6 +299,7 @@ public class WotrRegistries {
         event.register(MODIFIER_SOURCES);
         event.register(TARGET_AREA_SHAPES);
         event.register(RIFT_PARAMETER_TYPES);
+        event.register(INSTANT_LOOT_TYPES);
 
         // worldgen registries
         event.register(THEME_SOURCE_TYPE);

--- a/src/main/java/com/wanderersoftherift/wotr/init/loot/WotrLootItemFunctionTypes.java
+++ b/src/main/java/com/wanderersoftherift/wotr/init/loot/WotrLootItemFunctionTypes.java
@@ -3,9 +3,11 @@ package com.wanderersoftherift.wotr.init.loot;
 import com.wanderersoftherift.wotr.WanderersOfTheRift;
 import com.wanderersoftherift.wotr.loot.functions.AbilityHolderFunction;
 import com.wanderersoftherift.wotr.loot.functions.GearSocketsFunction;
+import com.wanderersoftherift.wotr.loot.functions.RewardInstantLootFunction;
 import com.wanderersoftherift.wotr.loot.functions.RollGearFunction;
 import com.wanderersoftherift.wotr.loot.functions.RunegemsFunction;
 import com.wanderersoftherift.wotr.loot.functions.SetPriceFunction;
+import com.wanderersoftherift.wotr.loot.functions.WrappingConditionalLootFunction;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.world.level.storage.loot.functions.LootItemFunctionType;
 import net.neoforged.neoforge.registries.DeferredHolder;
@@ -27,4 +29,8 @@ public class WotrLootItemFunctionTypes {
             .register(
                     "set_price", () -> new LootItemFunctionType<>(SetPriceFunction.CODEC)
             );
+    public static final DeferredHolder<LootItemFunctionType<?>, LootItemFunctionType<RewardInstantLootFunction>> REWARD_INSTANT_LOOT_FUNCTION = LOOT_ITEM_FUNCTION_TYPES
+            .register("reward_instant_loot", () -> RewardInstantLootFunction.TYPE);
+    public static final DeferredHolder<LootItemFunctionType<?>, LootItemFunctionType<WrappingConditionalLootFunction>> WRAP_CONDITION_FUNCTION = LOOT_ITEM_FUNCTION_TYPES
+            .register("wrap_condition", () -> WrappingConditionalLootFunction.TYPE);
 }

--- a/src/main/java/com/wanderersoftherift/wotr/init/quest/WotrRewardTypes.java
+++ b/src/main/java/com/wanderersoftherift/wotr/init/quest/WotrRewardTypes.java
@@ -4,7 +4,9 @@ import com.mojang.serialization.MapCodec;
 import com.wanderersoftherift.wotr.WanderersOfTheRift;
 import com.wanderersoftherift.wotr.core.quest.Reward;
 import com.wanderersoftherift.wotr.core.quest.RewardProvider;
+import com.wanderersoftherift.wotr.core.quest.reward.AbilityResourceReward;
 import com.wanderersoftherift.wotr.core.quest.reward.CurrencyReward;
+import com.wanderersoftherift.wotr.core.quest.reward.HealReward;
 import com.wanderersoftherift.wotr.core.quest.reward.ItemReward;
 import com.wanderersoftherift.wotr.core.quest.reward.ProgressionTrackPointReward;
 import com.wanderersoftherift.wotr.core.quest.reward.provider.CurrencyRewardProvider;
@@ -31,6 +33,10 @@ public final class WotrRewardTypes {
             .register("progression_track", () -> ProgressionTrackRewardProvider.CODEC);
     public static final Supplier<DualCodec<? extends Reward>> ITEM_REWARD = registerWithFixedProvider("item",
             () -> ItemReward.TYPE);
+    public static final Supplier<DualCodec<? extends Reward>> HEAL_REWARD = registerWithFixedProvider("heal",
+            () -> HealReward.TYPE);
+    public static final Supplier<DualCodec<? extends Reward>> ABILITY_RESOURCE_REWARD = registerWithFixedProvider(
+            "ability_resource", () -> AbilityResourceReward.TYPE);
     public static final Supplier<DualCodec<? extends Reward>> CURRENCY_REWARD = REWARD_TYPES.register("currency",
             () -> CurrencyReward.TYPE);
     public static final Supplier<DualCodec<? extends Reward>> PROGRESSION_TRACK_REWARD = REWARD_TYPES

--- a/src/main/java/com/wanderersoftherift/wotr/loot/InstantLoot.java
+++ b/src/main/java/com/wanderersoftherift/wotr/loot/InstantLoot.java
@@ -1,0 +1,31 @@
+package com.wanderersoftherift.wotr.loot;
+
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.MapCodec;
+import com.wanderersoftherift.wotr.init.WotrDataComponentType;
+import com.wanderersoftherift.wotr.init.WotrRegistries;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
+
+import java.util.function.Function;
+
+public interface InstantLoot {
+
+    Codec<InstantLoot> CODEC = WotrRegistries.INSTANT_LOOT_TYPES.byNameCodec()
+            .dispatch("loot_type", InstantLoot::codec, Function.identity());
+
+    MapCodec<? extends InstantLoot> codec();
+
+    static boolean tryConsume(ItemStack stack, Player player) {
+        var component = stack.get(WotrDataComponentType.INSTANT_LOOT);
+        if (component != null) {
+            component.applyToPlayer(player, stack.getCount());
+            stack.setCount(0);
+            return true;
+        }
+        return false;
+    }
+
+    void applyToPlayer(Player player, int count);
+
+}

--- a/src/main/java/com/wanderersoftherift/wotr/loot/InstantLootEventHandler.java
+++ b/src/main/java/com/wanderersoftherift/wotr/loot/InstantLootEventHandler.java
@@ -1,0 +1,24 @@
+package com.wanderersoftherift.wotr.loot;
+
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.fml.common.EventBusSubscriber;
+import net.neoforged.neoforge.event.ItemStackedOnOtherEvent;
+import net.neoforged.neoforge.event.entity.player.ItemEntityPickupEvent;
+
+@EventBusSubscriber
+public class InstantLootEventHandler {
+
+    @SubscribeEvent
+    public static void handlePickup(ItemEntityPickupEvent.Pre event) {
+        InstantLoot.tryConsume(event.getItemEntity().getItem(), event.getPlayer());
+    }
+
+    @SubscribeEvent
+    public static void handleMerge(ItemStackedOnOtherEvent event) {
+        if (InstantLoot.tryConsume(
+                event.getCarriedItem() /* should be getStackedOnItem but someone@neoforge swapped them around */,
+                event.getPlayer())) {
+            event.setCanceled(true);
+        }
+    }
+}

--- a/src/main/java/com/wanderersoftherift/wotr/loot/RewardInstantLoot.java
+++ b/src/main/java/com/wanderersoftherift/wotr/loot/RewardInstantLoot.java
@@ -1,0 +1,28 @@
+package com.wanderersoftherift.wotr.loot;
+
+import com.mojang.serialization.MapCodec;
+import com.wanderersoftherift.wotr.core.quest.Reward;
+import net.minecraft.world.entity.player.Player;
+
+import java.util.List;
+
+public record RewardInstantLoot(List<Reward> rewards) implements InstantLoot {
+    public static final MapCodec<RewardInstantLoot> CODEC = Reward.DIRECT_CODEC.listOf()
+            .fieldOf("rewards")
+            .xmap(RewardInstantLoot::new, RewardInstantLoot::rewards);
+
+    @Override
+    public MapCodec<? extends InstantLoot> codec() {
+        return CODEC;
+    }
+
+    @Override
+    public void applyToPlayer(Player player, int count) {
+        for (int i = 0; i < count; i++) {
+            for (var reward : rewards) {
+                reward.apply(player);
+            }
+
+        }
+    }
+}

--- a/src/main/java/com/wanderersoftherift/wotr/loot/functions/RewardInstantLootFunction.java
+++ b/src/main/java/com/wanderersoftherift/wotr/loot/functions/RewardInstantLootFunction.java
@@ -1,0 +1,37 @@
+package com.wanderersoftherift.wotr.loot.functions;
+
+import com.wanderersoftherift.wotr.core.quest.RewardProvider;
+import com.wanderersoftherift.wotr.init.WotrDataComponentType;
+import com.wanderersoftherift.wotr.loot.RewardInstantLoot;
+import net.minecraft.core.component.DataComponentPatch;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.storage.loot.LootContext;
+import net.minecraft.world.level.storage.loot.functions.LootItemFunction;
+import net.minecraft.world.level.storage.loot.functions.LootItemFunctionType;
+
+import java.util.function.Supplier;
+
+public record RewardInstantLootFunction(RewardProvider reward) implements LootItemFunction {
+    public static final LootItemFunctionType<RewardInstantLootFunction> TYPE = new LootItemFunctionType<>(
+            RewardProvider.DIRECT_CODEC.fieldOf("reward")
+                    .xmap(RewardInstantLootFunction::new, RewardInstantLootFunction::reward)
+    );
+
+    public static LootItemFunction.Builder builder(Supplier<RewardProvider> reward) {
+        return WrappingConditionalLootFunction.wrappingBuilder(() -> new RewardInstantLootFunction(reward.get()));
+    }
+
+    @Override
+    public LootItemFunctionType<? extends LootItemFunction> getType() {
+        return TYPE;
+    }
+
+    @Override
+    public ItemStack apply(ItemStack itemStack, LootContext lootContext) {
+        var instantLootComponent = new RewardInstantLoot(reward.generateReward(lootContext));
+        itemStack.applyComponents(DataComponentPatch.builder()
+                .set(WotrDataComponentType.INSTANT_LOOT.get(), instantLootComponent)
+                .build());
+        return itemStack;
+    }
+}

--- a/src/main/java/com/wanderersoftherift/wotr/loot/functions/WrappingConditionalLootFunction.java
+++ b/src/main/java/com/wanderersoftherift/wotr/loot/functions/WrappingConditionalLootFunction.java
@@ -1,0 +1,59 @@
+package com.wanderersoftherift.wotr.loot.functions;
+
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.storage.loot.LootContext;
+import net.minecraft.world.level.storage.loot.functions.LootItemConditionalFunction;
+import net.minecraft.world.level.storage.loot.functions.LootItemFunction;
+import net.minecraft.world.level.storage.loot.functions.LootItemFunctionType;
+import net.minecraft.world.level.storage.loot.predicates.LootItemCondition;
+
+import java.util.List;
+import java.util.function.Supplier;
+
+public class WrappingConditionalLootFunction extends LootItemConditionalFunction {
+    private static final Codec<LootItemFunction> LOOT_FUNCTION_CODEC = BuiltInRegistries.LOOT_FUNCTION_TYPE
+            .byNameCodec()
+            .dispatch(LootItemFunction::getType, LootItemFunctionType::codec);
+    public static final LootItemFunctionType<WrappingConditionalLootFunction> TYPE = new LootItemFunctionType<>(
+            RecordCodecBuilder.mapCodec(
+                    instance -> instance.group(
+                            LootItemCondition.DIRECT_CODEC.listOf()
+                                    .optionalFieldOf("conditions", List.of())
+                                    .forGetter(WrappingConditionalLootFunction::getConditions),
+                            LOOT_FUNCTION_CODEC.fieldOf("base_function")
+                                    .forGetter(WrappingConditionalLootFunction::getBase)
+                    ).apply(instance, WrappingConditionalLootFunction::new)
+            ));
+
+    private final LootItemFunction base;
+
+    protected WrappingConditionalLootFunction(List<LootItemCondition> predicates, LootItemFunction base) {
+        super(predicates);
+        this.base = base;
+    }
+
+    public static LootItemFunction.Builder wrappingBuilder(Supplier<LootItemFunction> o) {
+        return simpleBuilder((conditions) -> new WrappingConditionalLootFunction(conditions, o.get()));
+    }
+
+    @Override
+    public LootItemFunctionType<? extends LootItemConditionalFunction> getType() {
+        return TYPE;
+    }
+
+    public List<LootItemCondition> getConditions() {
+        return predicates;
+    }
+
+    @Override
+    protected ItemStack run(ItemStack itemStack, LootContext lootContext) {
+        return base.apply(itemStack, lootContext);
+    }
+
+    public LootItemFunction getBase() {
+        return base;
+    }
+}

--- a/src/main/java/com/wanderersoftherift/wotr/mixin/MixinAbstractContainerMenu.java
+++ b/src/main/java/com/wanderersoftherift/wotr/mixin/MixinAbstractContainerMenu.java
@@ -1,0 +1,28 @@
+package com.wanderersoftherift.wotr.mixin;
+
+import com.wanderersoftherift.wotr.loot.InstantLoot;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.inventory.AbstractContainerMenu;
+import net.minecraft.world.inventory.ClickType;
+import net.minecraft.world.inventory.Slot;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(AbstractContainerMenu.class)
+public abstract class MixinAbstractContainerMenu {
+
+    @Shadow
+    public abstract Slot getSlot(int slotId);
+
+    @Inject(method = "doClick", at = @At("HEAD"), cancellable = true)
+    private void instantLootSpecial(int slotId, int button, ClickType clickType, Player player, CallbackInfo ci) {
+        if ((clickType == ClickType.QUICK_MOVE || clickType == ClickType.SWAP)
+                && InstantLoot.tryConsume(getSlot(slotId).getItem(), player)) {
+            ci.cancel();
+        }
+    }
+
+}

--- a/src/main/java/com/wanderersoftherift/wotr/serialization/DualCodec.java
+++ b/src/main/java/com/wanderersoftherift/wotr/serialization/DualCodec.java
@@ -11,5 +11,5 @@ import net.minecraft.network.codec.StreamCodec;
  * @param streamCodec
  * @param <T>
  */
-public record DualCodec<T>(MapCodec<T> codec, StreamCodec<RegistryFriendlyByteBuf, T> streamCodec) {
+public record DualCodec<T>(MapCodec<T> codec, StreamCodec<? super RegistryFriendlyByteBuf, T> streamCodec) {
 }

--- a/src/main/resources/wotr.mixins.json
+++ b/src/main/resources/wotr.mixins.json
@@ -14,6 +14,7 @@
         "AccessorStructureTemplate",
         "InvokerAbstractContainerMenu",
         "InvokerBlockBehaviour",
+        "MixinAbstractContainerMenu",
         "MixinAttributes",
         "MixinBlockAgeProcessor",
         "MixinBlock",


### PR DESCRIPTION
Adds instant loot Data Component.

Any item with this data component will be consumed instantly when:
- picked up
- clicked in an inventory

Healing potions have been changed to an instant loot.

Closes #581 

Future work: 
Apply in AOE. (or cast an ability when instant loot is collected)
Add some new items with custom models.

Could be used for an alternate Item Objective.