### PR TITLE
Refactor and Padding to Implicit

### DIFF
--- a/src/main/java/com/wanderersoftherift/wotr/client/tooltip/GearImplicitRenderer.java
+++ b/src/main/java/com/wanderersoftherift/wotr/client/tooltip/GearImplicitRenderer.java
@@ -13,10 +13,10 @@ import net.minecraft.world.inventory.tooltip.TooltipComponent;
 import org.joml.Matrix4f;
 
 public record GearImplicitRenderer(GearImplicitsComponent implicitsComponent) implements ClientTooltipComponent {
-    private static final int IMPLICIT_PADDING = 2;
     public static final Component IMPLICITS_LABEL = Component
             .translatable("tooltip." + WanderersOfTheRift.MODID + ".implicit")
             .withStyle(ChatFormatting.GRAY);
+    private static final int IMPLICIT_PADDING = 2;
 
     @Override
     public int getHeight(Font font) {

--- a/src/main/java/com/wanderersoftherift/wotr/client/tooltip/GearImplicitRenderer.java
+++ b/src/main/java/com/wanderersoftherift/wotr/client/tooltip/GearImplicitRenderer.java
@@ -13,7 +13,7 @@ import net.minecraft.world.inventory.tooltip.TooltipComponent;
 import org.joml.Matrix4f;
 
 public record GearImplicitRenderer(GearImplicitsComponent implicitsComponent) implements ClientTooltipComponent {
-
+    private static final int IMPLICIT_PADDING = 2;
     public static final Component IMPLICITS_LABEL = Component
             .translatable("tooltip." + WanderersOfTheRift.MODID + ".implicit")
             .withStyle(ChatFormatting.GRAY);
@@ -25,7 +25,7 @@ public record GearImplicitRenderer(GearImplicitsComponent implicitsComponent) im
                 .stream()
                 .mapToInt(modifierInstance -> ModifierRenderHelper.countTooltips(modifierInstance, isKeyDown))
                 .sum();
-        return 12 * (1 + tooltipCount);
+        return font.lineHeight * (1 + tooltipCount);
     }
 
     @Override
@@ -44,21 +44,21 @@ public record GearImplicitRenderer(GearImplicitsComponent implicitsComponent) im
         var isKeyDown = ModifierRenderHelper.isKeyDown();
         font.drawInBatch("Implicits: ", (float) x, (float) y, ChatFormatting.GRAY.getColor(), true, matrix,
                 bufferSource, Font.DisplayMode.NORMAL, 0, LightTexture.FULL_BRIGHT);
-        y += 12;
+        y += font.lineHeight + IMPLICIT_PADDING;
         for (var modifier : implicitsComponent.implicits.modifierInstances()) {
-            ModifierRenderHelper.renderModifierEffectDescriptions(modifier, isKeyDown, font, x, y, 12, matrix,
+            ModifierRenderHelper.renderModifierEffectDescriptions(modifier, isKeyDown, font, x, y, font.lineHeight, matrix,
                     bufferSource);
-            y += 12 * ModifierRenderHelper.countTooltips(modifier, isKeyDown);
+            y += font.lineHeight * ModifierRenderHelper.countTooltips(modifier, isKeyDown) + IMPLICIT_PADDING;
         }
     }
 
     @Override
     public void renderImage(Font font, int x, int y, int width, int height, GuiGraphics guiGraphics) {
         var isKeyDown = ModifierRenderHelper.isKeyDown();
-        y += 12;
+        y += font.lineHeight + IMPLICIT_PADDING;
         for (var modifier : implicitsComponent.implicits.modifierInstances()) {
-            ModifierRenderHelper.renderModifierEffectIcons(modifier, isKeyDown, font, x, y, 12, guiGraphics);
-            y += 12 * ModifierRenderHelper.countTooltips(modifier, isKeyDown);
+            ModifierRenderHelper.renderModifierEffectIcons(modifier, isKeyDown, font, x, y, font.lineHeight, guiGraphics);
+            y += font.lineHeight * ModifierRenderHelper.countTooltips(modifier, isKeyDown) + IMPLICIT_PADDING;
         }
     }
 

--- a/src/main/java/com/wanderersoftherift/wotr/client/tooltip/GearImplicitRenderer.java
+++ b/src/main/java/com/wanderersoftherift/wotr/client/tooltip/GearImplicitRenderer.java
@@ -46,8 +46,8 @@ public record GearImplicitRenderer(GearImplicitsComponent implicitsComponent) im
                 bufferSource, Font.DisplayMode.NORMAL, 0, LightTexture.FULL_BRIGHT);
         y += font.lineHeight + IMPLICIT_PADDING;
         for (var modifier : implicitsComponent.implicits.modifierInstances()) {
-            ModifierRenderHelper.renderModifierEffectDescriptions(modifier, isKeyDown, font, x, y, font.lineHeight, matrix,
-                    bufferSource);
+            ModifierRenderHelper.renderModifierEffectDescriptions(modifier, isKeyDown, font, x, y, font.lineHeight,
+                    matrix, bufferSource);
             y += font.lineHeight * ModifierRenderHelper.countTooltips(modifier, isKeyDown) + IMPLICIT_PADDING;
         }
     }
@@ -57,7 +57,8 @@ public record GearImplicitRenderer(GearImplicitsComponent implicitsComponent) im
         var isKeyDown = ModifierRenderHelper.isKeyDown();
         y += font.lineHeight + IMPLICIT_PADDING;
         for (var modifier : implicitsComponent.implicits.modifierInstances()) {
-            ModifierRenderHelper.renderModifierEffectIcons(modifier, isKeyDown, font, x, y, font.lineHeight, guiGraphics);
+            ModifierRenderHelper.renderModifierEffectIcons(modifier, isKeyDown, font, x, y, font.lineHeight,
+                    guiGraphics);
             y += font.lineHeight * ModifierRenderHelper.countTooltips(modifier, isKeyDown) + IMPLICIT_PADDING;
         }
     }

--- a/src/main/java/com/wanderersoftherift/wotr/client/tooltip/GearSocketTooltipRenderer.java
+++ b/src/main/java/com/wanderersoftherift/wotr/client/tooltip/GearSocketTooltipRenderer.java
@@ -34,6 +34,7 @@ import java.util.Map;
 public record GearSocketTooltipRenderer(GearSocketComponent socketComponent) implements ClientTooltipComponent {
     private static final int SOCKET_LINE_HEIGHT = 20;
     private static final int MODIFIER_DESCRIPTION_HORIZONTAL_OFFSET = 30;
+    private static final int SOCKET_HEIGHT_PADDING = 2;
     private static final Map<RunegemShape, ResourceLocation> SHAPE_TEXTURES = Map.of(
             RunegemShape.CIRCLE, WanderersOfTheRift.id("textures/tooltip/runegem/shape/circle.png"),
             RunegemShape.DIAMOND, WanderersOfTheRift.id("textures/tooltip/runegem/shape/diamond.png"),
@@ -45,17 +46,17 @@ public record GearSocketTooltipRenderer(GearSocketComponent socketComponent) imp
 
     @Override
     public int getHeight(@NotNull Font font) {
-        int baseHeight = font.lineHeight + 2;
+        int baseHeight = font.lineHeight + SOCKET_HEIGHT_PADDING;
 
         var isKeyDown = ModifierRenderHelper.isKeyDown();
         if (!isKeyDown) {
-            baseHeight += font.lineHeight + 2;
+            baseHeight += font.lineHeight + SOCKET_HEIGHT_PADDING;
         }
 
         int contentHeight = socketComponent.gearSocket().stream().mapToInt(socket -> {
             var socketModifier = socket.modifier();
             if (socketModifier.isPresent() && socket.runegem().isPresent()) {
-                return SOCKET_LINE_HEIGHT + 12 * ModifierRenderHelper.countTooltips(socketModifier.get(), isKeyDown);
+                return SOCKET_LINE_HEIGHT + font.lineHeight * ModifierRenderHelper.countTooltips(socketModifier.get(), isKeyDown);
             } else {
                 return SOCKET_LINE_HEIGHT;
             }
@@ -104,7 +105,7 @@ public record GearSocketTooltipRenderer(GearSocketComponent socketComponent) imp
                             WotrKeyMappings.SHOW_TOOLTIP_INFO.getKey().getDisplayName().getString()),
                     pX, pY, ChatFormatting.DARK_GRAY.getColor(), true, transform, buffer, Font.DisplayMode.NORMAL, 0,
                     LightTexture.FULL_BRIGHT);
-            pY += font.lineHeight + 2;
+            pY += font.lineHeight + SOCKET_HEIGHT_PADDING;
         }
 
         var used = new ArrayList<GearSocket>(socketComponent.gearSocket().size());
@@ -134,14 +135,14 @@ public record GearSocketTooltipRenderer(GearSocketComponent socketComponent) imp
 
             int tooltipCount = ModifierRenderHelper.countTooltips(modifierInstance, isKeyDown);
             for (int i = 0; i < tooltipCount; i++) {
-                font.drawInBatch(Component.literal(">"), pX + 20, pY + 12 * i - 1, ChatFormatting.DARK_GRAY.getColor(),
+                font.drawInBatch(Component.literal(">"), pX + 20, pY + font.lineHeight * i - 1, ChatFormatting.DARK_GRAY.getColor(),
                         true, transform, buffer, Font.DisplayMode.NORMAL, 0, LightTexture.FULL_BRIGHT);
             }
 
             ModifierRenderHelper.renderModifierEffectDescriptions(modifierInstance, isKeyDown, font,
-                    pX + MODIFIER_DESCRIPTION_HORIZONTAL_OFFSET, pY - 1, 12, transform, buffer);
+                    pX + MODIFIER_DESCRIPTION_HORIZONTAL_OFFSET, pY - 1, font.lineHeight, transform, buffer);
 
-            pY += 12 * tooltipCount + SOCKET_LINE_HEIGHT - 12;
+            pY += font.lineHeight * tooltipCount + SOCKET_LINE_HEIGHT - font.lineHeight;
         }
 
         for (GearSocket ignored : unused) {
@@ -167,7 +168,7 @@ public record GearSocketTooltipRenderer(GearSocketComponent socketComponent) imp
         y += 10;
 
         if (!isKeyDown) {
-            y += font.lineHeight + 2;
+            y += font.lineHeight + SOCKET_HEIGHT_PADDING;
         }
 
         var used = new ArrayList<GearSocket>(socketComponent.gearSocket().size());
@@ -202,11 +203,11 @@ public record GearSocketTooltipRenderer(GearSocketComponent socketComponent) imp
             painted = true;
 
             ModifierRenderHelper.renderModifierEffectIcons(modifierInstance, isKeyDown, font,
-                    x + MODIFIER_DESCRIPTION_HORIZONTAL_OFFSET, y + 4, 12, guiGraphics);
+                    x + MODIFIER_DESCRIPTION_HORIZONTAL_OFFSET, y + 4, font.lineHeight, guiGraphics);
 
             int tooltipCount = ModifierRenderHelper.countTooltips(modifierInstance, isKeyDown);
-            y += 12 * tooltipCount;
-            y += SOCKET_LINE_HEIGHT - 12;
+            y += font.lineHeight * tooltipCount;
+            y += SOCKET_LINE_HEIGHT - font.lineHeight;
         }
 
         painted = false;

--- a/src/main/java/com/wanderersoftherift/wotr/client/tooltip/GearSocketTooltipRenderer.java
+++ b/src/main/java/com/wanderersoftherift/wotr/client/tooltip/GearSocketTooltipRenderer.java
@@ -56,7 +56,8 @@ public record GearSocketTooltipRenderer(GearSocketComponent socketComponent) imp
         int contentHeight = socketComponent.gearSocket().stream().mapToInt(socket -> {
             var socketModifier = socket.modifier();
             if (socketModifier.isPresent() && socket.runegem().isPresent()) {
-                return SOCKET_LINE_HEIGHT + font.lineHeight * ModifierRenderHelper.countTooltips(socketModifier.get(), isKeyDown);
+                return SOCKET_LINE_HEIGHT
+                        + font.lineHeight * ModifierRenderHelper.countTooltips(socketModifier.get(), isKeyDown);
             } else {
                 return SOCKET_LINE_HEIGHT;
             }
@@ -135,8 +136,9 @@ public record GearSocketTooltipRenderer(GearSocketComponent socketComponent) imp
 
             int tooltipCount = ModifierRenderHelper.countTooltips(modifierInstance, isKeyDown);
             for (int i = 0; i < tooltipCount; i++) {
-                font.drawInBatch(Component.literal(">"), pX + 20, pY + font.lineHeight * i - 1, ChatFormatting.DARK_GRAY.getColor(),
-                        true, transform, buffer, Font.DisplayMode.NORMAL, 0, LightTexture.FULL_BRIGHT);
+                font.drawInBatch(Component.literal(">"), pX + 20, pY + font.lineHeight * i - 1,
+                        ChatFormatting.DARK_GRAY.getColor(), true, transform, buffer, Font.DisplayMode.NORMAL, 0,
+                        LightTexture.FULL_BRIGHT);
             }
 
             ModifierRenderHelper.renderModifierEffectDescriptions(modifierInstance, isKeyDown, font,


### PR DESCRIPTION
closes #359 

Refactors some of the magical numbers in the tooltips for the gear modifiers. Also added a padding to the implicits as some overlap with headers was occurring. 

Additionally I came across this rendering bug which was when a item is first found with an implicit it appears above the sockets and is clipped by the [Left Shift] text and once you reload the world the implicits move to below the socket and the clipping is no longer an issue, not sure what this is related to but was behaviour that I found.
<img width="492" height="422" alt="2 found" src="https://github.com/user-attachments/assets/d5b18988-1451-4f9d-8c7a-deb96ce4849b" />
<img width="480" height="407" alt="reloaded" src="https://github.com/user-attachments/assets/5475541a-c8d4-4333-8b1c-10203a83a94e" />
